### PR TITLE
Fix: Use localized ajaxUrl in service presentation tab

### DIFF
--- a/dashboard/sections/services.php
+++ b/dashboard/sections/services.php
@@ -2630,7 +2630,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 formData.append('action', 'mobooking_save_service');
                 // Main nonce ('nonce') is already included in formData by virtue of being an input field
 
-                fetch(ajaxurl, { method: 'POST', body: formData })
+                fetch(window.mobookingDashboard.ajaxUrl, { method: 'POST', body: formData })
                 .then(response => response.json())
                 .then(data => {
                     if (window.setButtonLoading) {
@@ -2703,7 +2703,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     imageFormData.append('service_id', currentServiceId);
                 }
 
-                fetch(ajaxurl, {
+                fetch(window.mobookingDashboard.ajaxUrl, {
                     method: 'POST',
                     body: imageFormData,
                     //contentType: false, // Not needed for fetch() with FormData


### PR DESCRIPTION
The inline JavaScript in `dashboard/sections/services.php` for handling service image uploads and form submission was directly calling `ajaxurl`. This variable was not defined in the local scope, leading to a `ReferenceError` and preventing image uploads and potentially other save operations on the presentation tab.

This commit updates the script to use `window.mobookingDashboard.ajaxUrl`, which is correctly localized and provides the necessary URL for AJAX requests within the WordPress dashboard environment.