### PR TITLE
Fix: Correct case sensitivity in autoloader path for Core\Loader

### DIFF
--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -22,7 +22,11 @@ spl_autoload_register(function ($class) {
     $relative_class = str_replace('MoBooking\\', '', $class);
     
     // Convert namespace separators to directory separators
-    $file = MOBOOKING_PATH . '/classes/' . str_replace('\\', '/', $relative_class) . '.php';
+    if ($relative_class === 'Core\Loader') {
+        $file = MOBOOKING_PATH . '/classes/core/Loader.php';
+    } else {
+        $file = MOBOOKING_PATH . '/classes/' . str_replace('\\', '/', $relative_class) . '.php';
+    }
 
     // Load the file if it exists
     if (file_exists($file)) {
@@ -45,7 +49,7 @@ spl_autoload_register(function ($class) {
  */
 function mobooking_load_critical_files() {
     $critical_files = array(
-        '/classes/Core/Loader.php',
+        '/classes/core/Loader.php',
         '/classes/Database/Manager.php',
     );
     


### PR DESCRIPTION
The MoBooking\Core\Loader class was not being found due to a case mismatch in the file path. The autoloader and the manual critical file loader were looking for 'classes/Core/Loader.php' (uppercase 'C' in Core), but the actual directory is 'classes/core/' (lowercase 'c').

This commit updates `includes/autoloader.php` to:
1. Use the correct lowercase 'core' path in the `mobooking_load_critical_files` function for `Loader.php`.
2. Add a specific condition in the `spl_autoload_register` function to use the lowercase 'core' path when resolving the `MoBooking\Core\Loader` class.

These changes ensure the autoloader correctly locates and loads the MoBooking\Core\Loader class, resolving the 'Fatal error: Uncaught Error: Class not found'.