### PR TITLE
Fix: Correct SQL syntax error due to 'rows' reserved keyword

### DIFF
--- a/classes/Database/manager.php
+++ b/classes/Database/manager.php
@@ -100,7 +100,7 @@ class Manager {
             unit varchar(50) NULL,
             min_length int(11) NULL,
             max_length int(11) NULL,
-            rows int(11) NULL,
+            option_rows int(11) NULL,
             display_order int(11) DEFAULT 0,
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/classes/Services/ServiceOptionsManager.php
+++ b/classes/Services/ServiceOptionsManager.php
@@ -81,7 +81,7 @@ class ServiceOptionsManager {
             'unit' => isset($data['unit']) ? sanitize_text_field($data['unit']) : '',
             'min_length' => isset($data['min_length']) && $data['min_length'] !== '' ? absint($data['min_length']) : null,
             'max_length' => isset($data['max_length']) && $data['max_length'] !== '' ? absint($data['max_length']) : null,
-            'rows' => isset($data['rows']) ? absint($data['rows']) : 3,
+            'option_rows' => isset($data['rows']) ? absint($data['rows']) : 3,
             'display_order' => isset($data['display_order']) ? absint($data['display_order']) : $this->get_next_display_order($data['service_id'])
         );
         
@@ -482,7 +482,7 @@ class ServiceOptionsManager {
                 'unit' => isset($_POST['unit']) ? trim($_POST['unit']) : '',
                 'min_length' => isset($_POST['min_length']) && $_POST['min_length'] !== '' ? absint($_POST['min_length']) : null,
                 'max_length' => isset($_POST['max_length']) && $_POST['max_length'] !== '' ? absint($_POST['max_length']) : null,
-                'rows' => isset($_POST['rows']) ? absint($_POST['rows']) : 3,
+                'option_rows' => isset($_POST['rows']) ? absint($_POST['rows']) : 3,
                 'options' => isset($_POST['options']) ? trim($_POST['options']) : '',
                 'option_label' => isset($_POST['option_label']) ? trim($_POST['option_label']) : ''
             );


### PR DESCRIPTION
The `CREATE TABLE` statement for `wp_mobooking_service_options` used 'rows' as a column name. 'ROWS' is a reserved keyword in newer MySQL/MariaDB versions, causing a syntax error and preventing table creation. This led to subsequent errors with foreign key constraints and PHP warnings about headers already sent.

This commit addresses the issue by:
1. Renaming the `rows` column to `option_rows` in the `create_service_options_table` method in `classes/Database/manager.php`.
2. Updating the `save_option` and `ajax_save_option` methods in `classes/Services/ServiceOptionsManager.php` to use the new `option_rows` column name when preparing data for database insertion and updates.

This change should allow the `wp_mobooking_service_options` table and all dependent tables and foreign keys to be created correctly.