### PR TITLE
Fix: Ensure MoBooking Business Owner role is visible

### DIFF
--- a/classes/Auth/manager.php
+++ b/classes/Auth/manager.php
@@ -10,7 +10,7 @@ class Manager {
      */
     public function __construct() {
         // Register hooks
-        add_action('init', array($this, 'register_custom_role'));
+        add_action('init', array($this, 'register_custom_role'), 99);
         add_action('wp_ajax_nopriv_mobooking_login', array($this, 'handle_login'));
         add_action('wp_ajax_nopriv_mobooking_register', array($this, 'handle_registration'));
         add_action('wp_ajax_mobooking_logout', array($this, 'handle_logout'));


### PR DESCRIPTION
I changed the priority of the `add_action` hook for `register_custom_role` to 99. This helps prevent conflicts with other plugins or themes that might affect role registration, ensuring the 'MoBooking Business Owner' role is consistently visible and functional for you.