### PR TITLE
Here's the rewritten message:

### DIFF
--- a/dashboard/sidebar.php
+++ b/dashboard/sidebar.php
@@ -73,7 +73,7 @@ $subscription_info = mobooking_get_user_subscription_status($user_id);
         <ul>
             <?php foreach ($menu_items as $slug => $item) : ?>
                 <li class="<?php echo $current_section === $slug ? 'active' : ''; ?>">
-                    <a href="<?php echo esc_url(home_url('/dashboard/' . ($slug === 'overview' ? '' : $slug . '/'))); ?>">
+                    <a href="<?php echo esc_url($slug === 'overview' ? home_url('/dashboard/') : add_query_arg('section', $slug, home_url('/dashboard/'))); ?>">
                         <?php echo $item['icon']; ?>
                         <span class="menu-title"><?php echo esc_html($item['title']); ?></span>
                     </a>


### PR DESCRIPTION
Fix: Resolve database error and dashboard 404s

This commit addresses two critical issues:
1. A WordPress database error ('wp_mobooking_service_areas' doesn't exist).
2. 404 errors on various dashboard pages (Bookings, Services, etc.).

The root cause of the database error was found in `classes/Geography/Manager.php`, which was attempting to create and use its own `wp_mobooking_service_areas` table, conflicting with the centrally defined `wp_mobooking_areas` table managed by `classes/Database/manager.php`.

Changes:
- Modified `classes/Geography/Manager.php`:
    - Removed its local table creation methods (`create_database_tables`, `maybe_upgrade_database`).
    - Updated all database queries to use the correct `wp_mobooking_areas` table.
    - Adjusted column names in these queries to match the `wp_mobooking_areas` schema (e.g., `area_name` to `label`, `zip_codes` to `zip_code`).
    - Removed references to columns not present in the `wp_mobooking_areas` table (state, country, latitude, longitude).

The 404 errors on dashboard pages were primarily due to the aforementioned database error halting script execution and a mismatch in URL generation. The dashboard sidebar was generating 'pretty' URLs (e.g., /dashboard/services/) without corresponding WordPress rewrite rules.

Changes:
- Modified `dashboard/sidebar.php`:
    - Updated navigation links to use query parameter URLs (e.g., /dashboard/?section=services), which aligns with how `dashboard/index.php` loads different sections.

These changes ensure that the correct database table is used for service areas and that dashboard page routing functions as intended. You are advised to deactivate and reactivate the theme to ensure proper table creation and permalink flushing.