### PR TITLE
Fix: Correct dashboard section routing on live site

### DIFF
--- a/dashboard/sidebar.php
+++ b/dashboard/sidebar.php
@@ -73,7 +73,7 @@ $subscription_info = mobooking_get_user_subscription_status($user_id);
         <ul>
             <?php foreach ($menu_items as $slug => $item) : ?>
                 <li class="<?php echo $current_section === $slug ? 'active' : ''; ?>">
-                    <a href="<?php echo esc_url($slug === 'overview' ? home_url('/dashboard/') : add_query_arg('section', $slug, home_url('/dashboard/'))); ?>">
+                    <a href="<?php echo esc_url($slug === 'overview' ? home_url('/dashboard/') : home_url('/dashboard/' . $slug . '/')); ?>">
                         <?php echo $item['icon']; ?>
                         <span class="menu-title"><?php echo esc_html($item['title']); ?></span>
                     </a>

--- a/functions.php
+++ b/functions.php
@@ -114,6 +114,15 @@ function mobooking_admin_notices() {
 add_action('admin_notices', 'mobooking_admin_notices');
 
 /**
+ * Add custom rewrite rules for the dashboard sections.
+ */
+function mobooking_custom_rewrite_rules() {
+    add_rewrite_tag('%section%', '([^&]+)');
+    add_rewrite_rule('^dashboard/([^/]*)/?', 'index.php?pagename=dashboard&section=\$matches[1]', 'top');
+}
+add_action('init', 'mobooking_custom_rewrite_rules');
+
+/**
  * Flush rewrite rules on theme activation
  */
 function mobooking_flush_rewrite_rules() {


### PR DESCRIPTION
The issue involved several dashboard sections (Bookings, Services, etc.) incorrectly loading the main Dashboard overview page on the live server, despite working correctly locally. This was likely due to issues with URL query parameter handling or rewrite rule interpretation on the live environment.

This commit addresses the problem by:

1.  Defining a custom WordPress rewrite tag (`%section%`) and rule. This maps URLs like `/dashboard/section_name/` to `index.php?pagename=dashboard&section=section_name`. This makes the section identifier part of the URL path rather than a query parameter, which is generally more robust.

2.  Updating the dashboard sidebar navigation link generation. Links now point to the new path-based URLs (e.g., `/dashboard/bookings/`) instead of query-based URLs (e.g., `/dashboard/?section=bookings`).

The theme already includes a mechanism to flush rewrite rules upon theme activation. You are also advised to manually re-save permalinks in WordPress admin (Settings > Permalinks) after these changes are deployed to ensure the new rules take effect.