### PR TITLE
Fix: Correct BookingFormManager class name instantiation

### DIFF
--- a/dashboard/sections/booking-form.php
+++ b/dashboard/sections/booking-form.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Initialize booking form manager
-$booking_form_manager = new \MoBooking\BookingForm\Manager();
+$booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
 $settings = $booking_form_manager->get_settings($user_id);
 $booking_url = $booking_form_manager->get_booking_form_url($user_id);
 $embed_url = $booking_form_manager->get_embed_url($user_id);
@@ -1454,7 +1454,7 @@ add_action('wp_ajax_mobooking_save_booking_form_settings', function() {
         );
         
         // Save settings using BookingForm Manager
-        $booking_form_manager = new \MoBooking\BookingForm\Manager();
+        $booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
         $result = $booking_form_manager->save_settings($user_id, $settings_data);
         
         if ($result) {
@@ -1515,7 +1515,7 @@ add_action('wp_ajax_mobooking_reset_booking_form_settings', function() {
             'custom_css' => ''
         );
         
-        $booking_form_manager = new \MoBooking\BookingForm\Manager();
+        $booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
         $result = $booking_form_manager->save_settings($user_id, $default_settings);
         
         if ($result) {

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -91,8 +91,8 @@ function mobooking_ajax_reset_booking_form_settings() {
         $user_id = get_current_user_id();
         
         // Reset settings using BookingForm Manager
-        if (class_exists('\MoBooking\BookingForm\Manager')) {
-            $booking_form_manager = new \MoBooking\BookingForm\Manager();
+        if (class_exists('\MoBooking\BookingForm\BookingFormManager')) {
+            $booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
             $result = $booking_form_manager->reset_settings($user_id);
         } else {
             // Fallback: Direct database reset


### PR DESCRIPTION
- Changed `MoBooking\BookingForm\Manager` to `MoBooking\BookingForm\BookingFormManager` in `dashboard/sections/booking-form.php` and `includes/ajax-handlers.php`.
- This resolves a PHP Fatal error 'Class not found' which was causing dashboard sections to be unavailable.