### PR TITLE
I've converted the dashboard sections into standalone pages.

### DIFF
--- a/dashboard/sidebar.php
+++ b/dashboard/sidebar.php
@@ -5,13 +5,46 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Get current section from URL
-$current_section = get_query_var('section', 'overview');
+// Determine current section from URL path
+$current_path = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+$path_parts = explode('/', $current_path);
 
-// Define dashboard menu items with proper sections
+// Default section
+$current_section = 'overview';
+
+// Extract section from path
+// Example paths: /page-services.php, /dashboard/, /dashboard/index.php
+if (strpos($current_path, 'page-') === 0 && strpos($current_path, '.php') !== false) {
+    // Handles /page-section.php
+    $current_section = str_replace(array('page-', '.php'), '', $current_path);
+} elseif (isset($path_parts[0]) && $path_parts[0] === 'dashboard') {
+    if (isset($path_parts[1]) && $path_parts[1] !== '' && $path_parts[1] !== 'index.php') {
+        // This case might be for future /dashboard/section/ URLs, but currently our new files are at root
+        // For now, if it's /dashboard/something, and that something isn't index.php,
+        // we'll try to see if it matches a known section.
+        // However, with the new structure, direct /dashboard/section/ URLs are less likely
+        // unless explicitly routed.
+        // This part might need refinement based on actual URL structures in use.
+        $potential_section = str_replace('.php', '', $path_parts[1]);
+         if (in_array($potential_section, ['overview', 'bookings', 'booking-form', 'services', 'discounts', 'areas', 'settings'])) {
+            $current_section = $potential_section;
+        }
+    } else {
+        // /dashboard/ or /dashboard/index.php defaults to overview
+        $current_section = 'overview';
+    }
+}
+// Fallback for root or unrecognized paths that should be overview
+elseif ($current_path === '' || $current_path === 'index.php') {
+    $current_section = 'overview';
+}
+
+
+// Define dashboard menu items with updated URLs
 $menu_items = array(
     'overview' => array(
         'title' => __('Dashboard', 'mobooking'),
+        'url' => home_url('/dashboard/'), // Default for dashboard index
         'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10 3H3V10H10V3Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M21 3H14V10H21V3Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -21,43 +54,46 @@ $menu_items = array(
     ),
     'bookings' => array(
         'title' => __('Bookings', 'mobooking'),
+        'url' => home_url('/page-bookings.php'),
         'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M16 2V6M8 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>'
     ),
     'booking-form' => array(
         'title' => __('Booking Form', 'mobooking'),
+        'url' => home_url('/page-booking-form.php'),
         'icon' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M17 2V4H20.0066C20.5552 4 21 4.44495 21 4.9934V21.0066C21 21.5552 20.5551 22 20.0066 22H3.9934C3.44476 22 3 21.5551 3 21.0066V4.9934C3 4.44476 3.44495 4 3.9934 4H7V2H17ZM7 6H5V20H19V6H17V8H7V6ZM9 16V18H7V16H9ZM9 13V15H7V13H9ZM9 10V12H7V10H9ZM15 4H9V6H15V4Z"></path></svg>'
     ),
     'services' => array(
         'title' => __('Services', 'mobooking'),
+        'url' => home_url('/page-services.php'),
         'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M16.5 9.40002L7.5 4.21002M3.27 6.96002L12 12.01L20.73 6.96002M12 22.08V12M21 16V8.00002C20.9996 7.6493 20.9071 7.30483 20.7315 7.00119C20.556 6.69754 20.3037 6.44539 20 6.27002L13 2.27002C12.696 2.09449 12.3511 2.00208 12 2.00208C11.6489 2.00208 11.304 2.09449 11 2.27002L4 6.27002C3.69626 6.44539 3.44398 6.69754 3.26846 7.00119C3.09294 7.30483 3.00036 7.6493 3 8.00002V16C3.00036 16.3508 3.09294 16.6952 3.26846 16.9989C3.44398 17.3025 3.69626 17.5547 4 17.73L11 21.73C11.304 21.9056 11.6489 21.998 12 21.998C12.3511 21.998 12.696 21.9056 13 21.73L20 17.73C20.3037 17.5547 20.556 17.3025 20.7315 16.9989C20.9071 16.6952 20.9996 16.3508 21 16Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>'
     ),
     'discounts' => array(
         'title' => __('Discount Codes', 'mobooking'),
+        'url' => home_url('/page-discounts.php'),
         'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>'
     ),
     'areas' => array(
         'title' => __('Service Areas', 'mobooking'),
+        'url' => home_url('/page-areas.php'),
         'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M8 18L1 22V6L8 2M8 18L16 22M8 18V2M16 22L23 18V2L16 6M16 22V6M16 6L8 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>'
     ),
     'settings' => array(
         'title' => __('Settings', 'mobooking'),
+        'url' => home_url('/page-settings.php'),
         'icon' => '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 <circle cx="12" cy="12" r="3"></circle>
 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
 </svg>'
     )
 );
-
-// Check for subscription status
-$subscription_info = mobooking_get_user_subscription_status($user_id);
 ?>
 
 <div class="mobooking-dashboard-sidebar">

--- a/includes/rewrite-rules.php
+++ b/includes/rewrite-rules.php
@@ -4,18 +4,115 @@
  */
 
 /**
- * Add custom rewrite rules for the dashboard sections.
+ * Add custom rewrite rules for the dashboard sections and query-based redirects.
  */
 function mobooking_custom_rewrite_rules() {
-    add_rewrite_tag('%section%', '([^&]+)');
-    add_rewrite_rule('^dashboard/([^/]*)/?', 'index.php?pagename=dashboard&section=\$matches[1]', 'top');
+    // Existing rule for path-based sections (e.g., /dashboard/services/)
+    add_rewrite_tag('%section%', '([^&]+)'); // Makes 'section' a query var for WP_Query
+    add_rewrite_rule('^dashboard/([^/]*)/?$', 'index.php?pagename=dashboard&section=$matches[1]', 'top');
+
+    // Rule for /dashboard/ or /dashboard (to default to overview)
+    // This might be handled by dashboard/index.php itself, but an explicit rule can be good.
+    // However, since page-overview.php is now the default in dashboard/index.php, this specific rule might not be strictly necessary
+    // if /dashboard/ correctly loads dashboard/index.php.
+    // add_rewrite_rule('^dashboard/?$', 'index.php?pagename=dashboard&section=overview', 'top');
+
+    // New rule for query parameter based sections (e.g., /dashboard?section=services or /dashboard/?section=services)
+    // This will internally rewrite to index.php with a custom query var `mob_page_redirect`
+    add_rewrite_rule('^dashboard(?:/)?\?section=([^&]+)', 'index.php?mob_page_redirect=$matches[1]', 'top');
 }
-add_action('init', 'mobooking_custom_rewrite_rules');
+add_action('init', 'mobooking_custom_rewrite_rules', 10, 0); // Added priority
 
 /**
- * Flush rewrite rules on theme activation
+ * Register custom query variables.
+ */
+function mobooking_register_query_vars($vars) {
+    $vars[] = 'section'; // Already handled by add_rewrite_tag for WP_Query, but good for filter.
+    $vars[] = 'mob_page_redirect';
+    return $vars;
+}
+add_filter('query_vars', 'mobooking_register_query_vars');
+
+/**
+ * Handle the actual redirection or content loading for mob_page_redirect.
+ */
+function mobooking_handle_page_redirect() {
+    $redirect_section = get_query_var('mob_page_redirect');
+
+    if ($redirect_section) {
+        $file_name = 'page-' . sanitize_key($redirect_section) . '.php';
+        $file_path = MOBOOKING_PATH . '/' . $file_name; // Files are in the root
+
+        if (file_exists($file_path)) {
+            // Before including, ensure necessary global variables are available if these files expect them
+            // For example, if they need WordPress user context:
+            global $current_user, $user_id;
+            if (is_user_logged_in()) {
+                $current_user = wp_get_current_user();
+                $user_id = $current_user->ID;
+            }
+
+            // If these page-*.php files expect to be within the dashboard's visual structure,
+            // dashboard/header.php and dashboard/footer.php (and sidebar) should be included here.
+            // This mimics how dashboard/index.php would have loaded them.
+
+            // Check if header/sidebar/footer are needed based on how page-*.php files are structured.
+            // For now, assuming they might need the dashboard context.
+
+            $dashboard_header_path = MOBOOKING_PATH . '/dashboard/header.php';
+            if (file_exists($dashboard_header_path)) {
+                include $dashboard_header_path;
+            }
+
+            // It's assumed page-*.php files might need $current_section to be set.
+            // For direct loading via mob_page_redirect, $current_section should match $redirect_section.
+            $current_section = $redirect_section;
+
+
+            // Initialize managers if they are used directly in page-*.php files
+            // This mirrors what was done in dashboard/index.php for overview
+            // These should ideally be singletons or managed more centrally in a real app.
+            if (!isset($GLOBALS['bookings_manager'])) {
+                 $GLOBALS['bookings_manager'] = new \MoBooking\Bookings\Manager();
+            }
+            if (!isset($GLOBALS['services_manager'])) {
+                 $GLOBALS['services_manager'] = new \MoBooking\Services\ServicesManager();
+            }
+            if (!isset($GLOBALS['geography_manager'])) {
+                 $GLOBALS['geography_manager'] = new \MoBooking\Geography\Manager();
+            }
+            if (!isset($GLOBALS['settings_manager'])) {
+                 $GLOBALS['settings_manager'] = new \MoBooking\Database\SettingsManager();
+                 // $settings might also be needed if page-*.php uses it directly.
+                 // $GLOBALS['settings'] = $GLOBALS['settings_manager']->get_settings($user_id);
+            }
+
+
+            include $file_path;
+
+            $dashboard_footer_path = MOBOOKING_PATH . '/dashboard/footer.php';
+            if (file_exists($dashboard_footer_path)) {
+                include $dashboard_footer_path;
+            }
+            exit; // Important to stop WordPress from loading the original query's template
+        } else {
+            // File not found, redirect to main dashboard or a 404 page
+            // For now, redirect to the main dashboard page
+            wp_redirect(home_url('/dashboard/'));
+            exit;
+        }
+    }
+}
+add_action('template_redirect', 'mobooking_handle_page_redirect');
+
+/**
+ * Flush rewrite rules on theme activation.
+ * It's recommended to visit the Permalinks settings page in WP Admin
+ * if you manually change rewrite rules to ensure they are applied.
  */
 function mobooking_flush_rewrite_rules() {
+    // Call mobooking_custom_rewrite_rules to ensure rules are added before flushing
+    mobooking_custom_rewrite_rules();
     flush_rewrite_rules();
 }
 add_action('after_switch_theme', 'mobooking_flush_rewrite_rules');

--- a/page-areas.php
+++ b/page-areas.php
@@ -1,0 +1,1905 @@
+<?php
+// dashboard/sections/areas.php - Enhanced Service Areas Management with Local JSON Data
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Initialize managers
+$geography_manager = new \MoBooking\Geography\Manager();
+$areas = $geography_manager->get_user_areas($user_id);
+
+// Get coverage statistics
+$total_areas = count($areas);
+$active_areas = count(array_filter($areas, function($area) { return $area->active; }));
+
+// Get user's selected country
+$selected_country = get_user_meta($user_id, 'mobooking_service_country', true);
+
+// Updated supported countries with local JSON data indicators
+$supported_countries = $geography_manager->get_supported_countries();
+
+$script_data = $geography_manager->get_areas_script_data();
+?>
+<script type="text/javascript">
+    window.mobooking_area_vars = <?php echo json_encode($script_data); ?>;
+    window.ajax_object = window.mobooking_area_vars; // Define ajax_object immediately
+    // mobooking_current_country is part of mobooking_area_vars now, so no separate global needed unless specifically used outside this object.
+    // If window.mobooking_current_country is used directly elsewhere, it can be set:
+    // window.mobooking_current_country = <?php echo json_encode($script_data['current_country']); ?>;
+    // However, it's better to access it via window.mobooking_area_vars.current_country
+</script>
+
+<div class="areas-section enhanced-areas">
+    <div class="areas-header">
+        <div class="areas-header-content">
+            <div class="areas-title-group">
+                <h1 class="areas-main-title">
+                    <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                        <circle cx="12" cy="10" r="3"/>
+                    </svg>
+                    <?php _e('Service Areas', 'mobooking'); ?>
+                </h1>
+                <p class="areas-subtitle"><?php _e('Manage your service coverage areas with real ZIP code data', 'mobooking'); ?></p>
+            </div>
+
+            <div class="areas-stats">
+                <div class="stat-item">
+                    <span class="stat-number"><?php echo $total_areas; ?></span>
+                    <span class="stat-label"><?php _e('Total Areas', 'mobooking'); ?></span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-number"><?php echo $active_areas; ?></span>
+                    <span class="stat-label"><?php _e('Active Areas', 'mobooking'); ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php if (empty($selected_country)) : ?>
+        <!-- Step 1: Country Selection -->
+        <div class="country-selection-container">
+            <div class="country-selection-card">
+                <div class="selection-header">
+                    <div class="selection-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <circle cx="12" cy="12" r="10"/>
+                            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+                        </svg>
+                    </div>
+                    <h2><?php _e('Select Your Service Country', 'mobooking'); ?></h2>
+                    <p><?php _e('Choose your primary service country to access comprehensive area and ZIP code data. Nordic countries (Sweden, Norway, Denmark, Finland) use local high-quality data, while other countries use external APIs.', 'mobooking'); ?></p>
+                </div>
+
+                <div class="country-selection-form">
+                    <div class="form-group">
+                        <label for="country-select"><?php _e('Country', 'mobooking'); ?></label>
+                        <select id="country-select" class="country-dropdown">
+                            <option value=""><?php _e('Select a country...', 'mobooking'); ?></option>
+                            <?php foreach ($supported_countries as $code => $info) : ?>
+                                <option value="<?php echo esc_attr($code); ?>"
+                                        data-has-local-data="<?php echo isset($info['has_local_data']) && $info['has_local_data'] ? '1' : '0'; ?>"
+                                        data-has-api="<?php echo isset($info['has_api']) && $info['has_api'] ? '1' : '0'; ?>">
+                                    <?php echo esc_html($info['name']); ?>
+                                    <?php if (isset($info['has_local_data']) && $info['has_local_data']) : ?>
+                                        <span class="data-indicator">🏠</span>
+                                    <?php elseif (isset($info['has_api']) && $info['has_api']) : ?>
+                                        <span class="data-indicator">🌐</span>
+                                    <?php endif; ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="field-help">
+                            <?php _e('🏠 = Local high-quality data | 🌐 = External API data', 'mobooking'); ?>
+                        </p>
+                    </div>
+
+                    <div class="data-source-info" id="data-source-info" style="display: none;">
+                        <div class="info-card">
+                            <h4 id="data-source-title"></h4>
+                            <p id="data-source-description"></p>
+                        </div>
+                    </div>
+
+                    <button type="button" id="confirm-country-btn" class="btn-primary" disabled>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M20 6 9 17l-5-5"/>
+                        </svg>
+                        <?php _e('Confirm Country Selection', 'mobooking'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    <?php elseif (empty($areas)) : ?>
+        <!-- Step 2: Add First City -->
+        <div class="first-city-container">
+            <div class="first-city-card">
+                <div class="selection-header">
+                    <div class="selection-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                            <circle cx="12" cy="10" r="3"/>
+                        </svg>
+                    </div>
+                    <h2><?php printf(__('Add Your First City in %s', 'mobooking'), $supported_countries[$selected_country]['name']); ?></h2>
+
+                    <?php if (isset($supported_countries[$selected_country]['has_local_data']) && $supported_countries[$selected_country]['has_local_data']) : ?>
+                        <p><?php _e('Enter a city name and we\'ll fetch all available areas and neighborhoods with ZIP codes from our comprehensive local database.', 'mobooking'); ?></p>
+                        <div class="data-quality-badge local-data">
+                            <span class="badge-icon">🏠</span>
+                            <span class="badge-text"><?php _e('High-Quality Local Data', 'mobooking'); ?></span>
+                        </div>
+                    <?php else : ?>
+                        <p><?php _e('Enter a city name and we\'ll fetch all available areas and neighborhoods with ZIP codes from external data sources.', 'mobooking'); ?></p>
+                        <div class="data-quality-badge api-data">
+                            <span class="badge-icon">🌐</span>
+                            <span class="badge-text"><?php _e('External API Data', 'mobooking'); ?></span>
+                        </div>
+                    <?php endif; ?>
+                </div>
+
+                <div class="city-input-form">
+                    <div class="form-group">
+                        <label for="city-search"><?php _e('City Name', 'mobooking'); ?></label>
+                        <div class="search-input-group">
+                            <input type="text" id="city-search" class="city-search-input"
+                                   placeholder="<?php _e('Enter city name...', 'mobooking'); ?>" autocomplete="off">
+                            <button type="button" id="search-city-btn" class="search-btn">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <circle cx="11" cy="11" r="8"/>
+                                    <path d="m21 21-4.35-4.35"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <div id="city-suggestions" class="city-suggestions" style="display: none;"></div>
+                    </div>
+
+                    <div class="search-status" id="search-status" style="display: none;">
+                        <div class="status-content">
+                            <div class="status-spinner"></div>
+                            <span class="status-text"><?php _e('Searching for areas...', 'mobooking'); ?></span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="country-actions">
+                    <button type="button" id="change-country-btn" class="btn-secondary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M19 12H5M12 19l-7-7 7-7"/>
+                        </svg>
+                        <?php _e('Change Country', 'mobooking'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Areas Results -->
+        <div id="areas-results" class="areas-results" style="display: none;">
+            <div class="results-header">
+                <h3><?php _e('Select Areas to Add', 'mobooking'); ?></h3>
+                <p class="results-subtitle"></p>
+            </div>
+
+            <div class="areas-grid" id="areas-grid">
+                <!-- Area items will be populated here -->
+            </div>
+
+            <div class="selection-actions">
+                <div class="selection-info">
+                    <span id="selected-count">0</span> <?php _e('areas selected', 'mobooking'); ?>
+                </div>
+                <div class="action-buttons">
+                    <button type="button" id="select-all-btn" class="btn-outline">
+                        <?php _e('Select All', 'mobooking'); ?>
+                    </button>
+                    <button type="button" id="save-selected-btn" class="btn-primary" disabled>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+                            <polyline points="17,21 17,13 7,13 7,21"/>
+                            <polyline points="7,3 7,8 15,8"/>
+                        </svg>
+                        <?php _e('Save Selected Areas', 'mobooking'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    <?php else : ?>
+        <!-- Step 3: Manage Existing Areas -->
+        <div class="areas-management">
+            <div class="management-header">
+                <div class="header-content">
+                    <h2><?php printf(__('Service Areas in %s', 'mobooking'), $supported_countries[$selected_country]['name']); ?></h2>
+                    <div class="data-source-indicator">
+                        <?php if (isset($supported_countries[$selected_country]['has_local_data']) && $supported_countries[$selected_country]['has_local_data']) : ?>
+                            <span class="indicator local-data">
+                                <span class="indicator-icon">🏠</span>
+                                <?php _e('Local Data', 'mobooking'); ?>
+                            </span>
+                        <?php else : ?>
+                            <span class="indicator api-data">
+                                <span class="indicator-icon">🌐</span>
+                                <?php _e('API Data', 'mobooking'); ?>
+                            </span>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <div class="header-actions">
+                    <button type="button" id="add-more-areas-btn" class="btn-primary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="16"/>
+                            <line x1="8" y1="12" x2="16" y2="12"/>
+                        </svg>
+                        <?php _e('Add More Areas', 'mobooking'); ?>
+                    </button>
+                    <button type="button" id="change-country-manage-btn" class="btn-outline">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+                        </svg>
+                        <?php _e('Change Country', 'mobooking'); ?>
+                    </button>
+                </div>
+            </div>
+
+            <div class="areas-table-container">
+                <table class="areas-table">
+                    <thead>
+                        <tr>
+                            <th class="checkbox-col">
+                                <input type="checkbox" id="select-all-areas">
+                            </th>
+                            <th class="area-name-col"><?php _e('Area Name', 'mobooking'); ?></th>
+                            <th class="zip-codes-col"><?php _e('ZIP Codes', 'mobooking'); ?></th>
+                            <th class="state-col"><?php _e('State/Region', 'mobooking'); ?></th>
+                            <th class="status-col"><?php _e('Status', 'mobooking'); ?></th>
+                            <th class="actions-col"><?php _e('Actions', 'mobooking'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($areas as $area) : ?>
+                            <tr class="area-row" data-area-id="<?php echo $area->id; ?>">
+                                <td class="checkbox-col">
+                                    <input type="checkbox" class="area-checkbox" value="<?php echo $area->id; ?>">
+                                </td>
+                                <td class="area-name-col">
+                                    <div class="area-name">
+                                        <strong><?php echo esc_html($area->area_name); ?></strong>
+                                        <?php if (!empty($area->state)) : ?>
+                                            <span class="area-state"><?php echo esc_html($area->state); ?></span>
+                                        <?php endif; ?>
+                                    </div>
+                                </td>
+                                <td class="zip-codes-col">
+                                    <span class="zip-codes-display"><?php echo esc_html($area->zip_codes); ?></span>
+                                </td>
+                                <td class="state-col">
+                                    <?php echo esc_html($area->state ?: '—'); ?>
+                                </td>
+                                <td class="status-col">
+                                    <label class="status-toggle">
+                                        <input type="checkbox" class="area-status-toggle"
+                                               data-area-id="<?php echo $area->id; ?>"
+                                               <?php checked($area->active, 1); ?>>
+                                        <span class="toggle-slider"></span>
+                                        <span class="toggle-label">
+                                            <?php echo $area->active ? __('Active', 'mobooking') : __('Inactive', 'mobooking'); ?>
+                                        </span>
+                                    </label>
+                                </td>
+                                <td class="actions-col">
+                                    <div class="action-buttons">
+                                        <button type="button" class="btn-icon edit-area-btn"
+                                                data-area-id="<?php echo $area->id; ?>"
+                                                title="<?php _e('Edit Area', 'mobooking'); ?>">
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                                                <path d="m18.5 2.5 a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                                            </svg>
+                                        </button>
+                                        <button type="button" class="btn-icon delete-area-btn"
+                                                data-area-id="<?php echo $area->id; ?>"
+                                                title="<?php _e('Delete Area', 'mobooking'); ?>">
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <polyline points="3,6 5,6 21,6"/>
+                                                <path d="m19,6v14a2,2 0 0,1-2,2H7a2,2 0 0,1-2-2V6m3,0V4a2,2 0 0,1,2-2h4a2,2 0 0,1,2,2v2"/>
+                                                <line x1="10" y1="11" x2="10" y2="17"/>
+                                                <line x1="14" y1="11" x2="14" y2="17"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="bulk-actions">
+                <div class="bulk-actions-left">
+                    <select id="bulk-action-select">
+                        <option value=""><?php _e('Bulk Actions', 'mobooking'); ?></option>
+                        <option value="activate"><?php _e('Activate Selected', 'mobooking'); ?></option>
+                        <option value="deactivate"><?php _e('Deactivate Selected', 'mobooking'); ?></option>
+                        <option value="delete"><?php _e('Delete Selected', 'mobooking'); ?></option>
+                    </select>
+                    <button type="button" id="apply-bulk-action-btn" class="btn-secondary" disabled>
+                        <?php _e('Apply', 'mobooking'); ?>
+                    </button>
+                </div>
+
+                <div class="bulk-actions-right">
+                    <span class="areas-count">
+                        <?php printf(__('Showing %d of %d areas', 'mobooking'), count($areas), $total_areas); ?>
+                    </span>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+
+<!-- Enhanced JavaScript for Local JSON Support -->
+
+<script>
+// Complete JavaScript for dashboard/sections/areas.php with Local JSON Support
+document.addEventListener('DOMContentLoaded', function() {
+    /*
+    if (typeof window.mobooking_area_vars === 'undefined') { ... } // REMOVE THIS BLOCK
+    window.ajax_object = window.mobooking_area_vars; // This is now done in the script tag above
+    */
+
+    const EnhancedAreasManager = {
+        // Configuration
+        selectedAreas: new Set(),
+        isLoading: false,
+
+        // Initialize the manager
+        init: function() {
+            this.bindEvents();
+            this.setupDataSourceInfo();
+            this.initializeExistingElements();
+
+            console.log('Enhanced Areas Manager initialized');
+        },
+
+        // Bind all event listeners
+        bindEvents: function() {
+            // Country selection
+            const countrySelect = document.getElementById('country-select');
+            const confirmBtn = document.getElementById('confirm-country-btn');
+
+            if (countrySelect) {
+                countrySelect.addEventListener('change', this.handleCountryChange.bind(this));
+            }
+
+            if (confirmBtn) {
+                confirmBtn.addEventListener('click', this.confirmCountrySelection.bind(this));
+            }
+
+            // City search
+            const citySearch = document.getElementById('city-search');
+            const searchBtn = document.getElementById('search-city-btn');
+
+            if (citySearch) {
+                citySearch.addEventListener('input', this.handleCityInput.bind(this));
+                citySearch.addEventListener('keypress', this.handleCityKeypress.bind(this));
+            }
+
+            if (searchBtn) {
+                searchBtn.addEventListener('click', this.searchCityAreas.bind(this));
+            }
+
+            // Area selection and actions
+            document.addEventListener('click', this.handleDocumentClick.bind(this));
+            document.addEventListener('change', this.handleDocumentChange.bind(this));
+
+            // Save selected areas
+            const saveBtn = document.getElementById('save-selected-btn');
+            if (saveBtn) {
+                saveBtn.addEventListener('click', this.saveSelectedAreas.bind(this));
+            }
+
+            // Select all areas
+            const selectAllBtn = document.getElementById('select-all-btn');
+            if (selectAllBtn) {
+                selectAllBtn.addEventListener('click', this.toggleSelectAll.bind(this));
+            }
+
+            // Change country buttons
+            const changeCountryBtns = document.querySelectorAll('#change-country-btn, #change-country-manage-btn');
+            changeCountryBtns.forEach(btn => {
+                btn.addEventListener('click', this.resetCountrySelection.bind(this));
+            });
+
+            // Add more areas button
+            const addMoreBtn = document.getElementById('add-more-areas-btn');
+            if (addMoreBtn) {
+                addMoreBtn.addEventListener('click', this.showAddMoreAreas.bind(this));
+            }
+
+            // Area management events
+            this.bindAreaManagementEvents();
+        },
+
+        // Handle document-level click events
+        handleDocumentClick: function(e) {
+            // Area checkbox selection
+            if (e.target.matches('.area-checkbox')) {
+                this.handleAreaCheckboxChange(e.target);
+            }
+
+            // Area item clicks (to select checkbox)
+            if (e.target.closest('.area-item') && !e.target.matches('input')) {
+                const areaItem = e.target.closest('.area-item');
+                const checkbox = areaItem.querySelector('.area-checkbox');
+                if (checkbox) {
+                    checkbox.checked = !checkbox.checked;
+                    this.handleAreaCheckboxChange(checkbox);
+                }
+            }
+
+            // Delete area buttons
+            if (e.target.closest('.delete-area-btn')) {
+                e.preventDefault();
+                this.handleDeleteArea(e);
+            }
+
+            // Edit area buttons
+            if (e.target.closest('.edit-area-btn')) {
+                e.preventDefault();
+                this.handleEditArea(e);
+            }
+
+            // Bulk action apply button
+            if (e.target.matches('#apply-bulk-action-btn')) {
+                e.preventDefault();
+                this.handleBulkAction();
+            }
+
+            // Close notification
+            if (e.target.matches('.notification-close')) {
+                e.target.closest('.notification').remove();
+            }
+        },
+
+        // Handle document-level change events
+        handleDocumentChange: function(e) {
+            // Area status toggles
+            if (e.target.matches('.area-status-toggle')) {
+                this.handleStatusToggle(e);
+            }
+
+            // Select all areas checkbox
+            if (e.target.matches('#select-all-areas')) {
+                this.handleSelectAllAreas(e.target.checked);
+            }
+
+            // Individual area checkboxes in management table
+            if (e.target.matches('.area-checkbox')) {
+                this.updateBulkActionState();
+            }
+
+            // Bulk action select dropdown
+            if (e.target.matches('#bulk-action-select')) {
+                this.updateBulkActionState();
+            }
+        },
+
+        // Setup data source information
+        setupDataSourceInfo: function() {
+            this.dataSourceDescriptions = {
+                local_data: {
+                    title: 'High-Quality Local Data',
+                    description: 'This country uses our comprehensive local database with accurate ZIP codes and area information. Data is stored locally for fast access and high reliability.'
+                },
+                api_data: {
+                    title: 'External API Data',
+                    description: 'This country uses data from external APIs including Zippopotam and GeoNames. Data quality is good but depends on external service availability.'
+                }
+            };
+        },
+
+        // Initialize existing elements
+        initializeExistingElements: function() {
+            // Update selection count if area results are already visible
+            if (document.getElementById('areas-results') && document.getElementById('areas-results').style.display !== 'none') {
+                this.updateSelectionCount();
+            }
+
+            // Update bulk action state if in management view
+            if (document.querySelector('.areas-management')) {
+                this.updateBulkActionState();
+            }
+        },
+
+        // Handle country selection change
+        handleCountryChange: function(e) {
+            const countrySelect = e.target;
+            const confirmBtn = document.getElementById('confirm-country-btn');
+            const infoDiv = document.getElementById('data-source-info');
+            const titleEl = document.getElementById('data-source-title');
+            const descEl = document.getElementById('data-source-description');
+
+            if (countrySelect.value) {
+                confirmBtn.disabled = false;
+
+                const option = countrySelect.selectedOptions[0];
+                const hasLocalData = option.dataset.hasLocalData === '1';
+                const hasApi = option.dataset.hasApi === '1';
+
+                let infoType = hasLocalData ? 'local_data' : 'api_data';
+                const info = this.dataSourceDescriptions[infoType];
+
+                if (titleEl && descEl) {
+                    titleEl.textContent = info.title;
+                    descEl.textContent = info.description;
+                }
+
+                if (infoDiv) {
+                    infoDiv.style.display = 'block';
+                    infoDiv.className = 'data-source-info ' + (hasLocalData ? 'local-data' : 'api-data');
+                }
+            } else {
+                confirmBtn.disabled = true;
+                if (infoDiv) {
+                    infoDiv.style.display = 'none';
+                }
+            }
+        },
+
+        // Confirm country selection
+        confirmCountrySelection: function() {
+            const countrySelect = document.getElementById('country-select');
+            if (!countrySelect || !countrySelect.value) {
+                this.showNotification('Please select a country first.', 'warning');
+                return;
+            }
+
+            const countryCode = countrySelect.value;
+            this.showLoadingState('Setting up your service country...');
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_set_service_country');
+            formData.append('country_code', countryCode);
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.showNotification(data.data.message || 'Country updated successfully!', 'success');
+                    setTimeout(() => {
+                        location.reload();
+                    }, 1000);
+                } else {
+                    this.showNotification(data.data || 'Error setting country', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                this.showNotification('Network error occurred', 'error');
+            })
+            .finally(() => {
+                this.hideLoadingState();
+            });
+        },
+
+        // Handle city input
+        handleCityInput: function(e) {
+            // Enable search button when user types
+            const searchBtn = document.getElementById('search-city-btn');
+            if (searchBtn) {
+                searchBtn.disabled = !e.target.value.trim();
+            }
+
+            // Future: Implement city suggestions/autocomplete here
+        },
+
+        // Handle city input keypress
+        handleCityKeypress: function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                this.searchCityAreas();
+            }
+        },
+
+        // Search for city areas
+        searchCityAreas: function() {
+            const cityInput = document.getElementById('city-search');
+            if (!cityInput) return;
+
+            const cityName = cityInput.value.trim();
+            if (!cityName) {
+                this.showNotification('Please enter a city name', 'warning');
+                cityInput.focus();
+                return;
+            }
+
+            // Get current country from various possible sources
+            const countryCode = this.getCurrentCountry();
+            if (!countryCode) {
+                this.showNotification('Country not set. Please refresh the page.', 'error');
+                return;
+            }
+
+            this.showSearchStatus();
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_fetch_city_areas');
+            formData.append('city_name', cityName);
+            formData.append('country_code', countryCode);
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.displayAreaResults(data.data);
+                } else {
+                    this.showNotification(data.data || 'Error fetching areas', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                this.showNotification('Network error occurred', 'error');
+            })
+            .finally(() => {
+                this.hideSearchStatus();
+            });
+        },
+
+        // Get current country code
+        getCurrentCountry: function() {
+            // Try to get from various sources
+            // const countryMeta = document.querySelector('meta[name="mobooking-country"]'); // This is fine if used
+            // if (countryMeta) return countryMeta.content;
+
+            // const countryData = document.querySelector('[data-country-code]'); // This is fine if used
+            // if (countryData) return countryData.dataset.countryCode;
+
+            // Extract from PHP variables if available (this is the primary one now)
+            if (typeof window.mobooking_area_vars !== 'undefined' && typeof window.mobooking_area_vars.current_country !== 'undefined') {
+                return window.mobooking_area_vars.current_country;
+            }
+
+            return null;
+        },
+
+        // Display area search results
+        displayAreaResults: function(data) {
+            const resultsDiv = document.getElementById('areas-results');
+            const gridDiv = document.getElementById('areas-grid');
+            const subtitle = resultsDiv?.querySelector('.results-subtitle');
+
+            if (!resultsDiv || !gridDiv) {
+                this.showNotification('Results container not found', 'error');
+                return;
+            }
+
+            // Update subtitle with data source info
+            const dataSourceText = data.is_nordic ? 'From local database' : 'From external APIs';
+            if (subtitle) {
+                subtitle.textContent = `${data.total_found || 0} areas found for ${data.city || 'city'} (${dataSourceText})`;
+            }
+
+            // Clear previous results
+            gridDiv.innerHTML = '';
+            this.selectedAreas.clear();
+
+            if (data.areas && data.areas.length > 0) {
+                data.areas.forEach(area => {
+                    const areaItem = this.createAreaItem(area);
+                    gridDiv.appendChild(areaItem);
+                });
+
+                resultsDiv.style.display = 'block';
+                resultsDiv.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            } else {
+                this.showNotification('No areas found for this city', 'info');
+            }
+
+            this.updateSelectionCount();
+        },
+
+        // Create area item element
+        createAreaItem: function(area) {
+            const item = document.createElement('div');
+            item.className = 'area-item';
+
+            const areaData = JSON.stringify(area).replace(/"/g, '&quot;');
+
+            item.innerHTML = `
+                <input type="checkbox" class="area-checkbox" data-area="${areaData}">
+                <div class="area-content">
+                    <div class="area-name">${this.escapeHtml(area.area_name || '')}</div>
+                    <div class="area-details">
+                        <span class="zip-code">${this.escapeHtml(area.zip_code || '')}</span>
+                        ${area.state ? `<span class="area-state">${this.escapeHtml(area.state)}</span>` : ''}
+                        <span class="data-source">${this.escapeHtml(area.source || 'Unknown')}</span>
+                    </div>
+                    ${area.latitude && area.longitude ? `
+                        <div class="area-coordinates">
+                            <small>📍 ${parseFloat(area.latitude).toFixed(4)}, ${parseFloat(area.longitude).toFixed(4)}</small>
+                        </div>
+                    ` : ''}
+                </div>
+            `;
+
+            return item;
+        },
+
+        // Handle area checkbox change
+        handleAreaCheckboxChange: function(checkbox) {
+            const areaData = checkbox.dataset.area;
+            if (checkbox.checked) {
+                this.selectedAreas.add(areaData);
+            } else {
+                this.selectedAreas.delete(areaData);
+            }
+            this.updateSelectionCount();
+        },
+
+        // Toggle select all areas
+        toggleSelectAll: function() {
+            const checkboxes = document.querySelectorAll('#areas-grid .area-checkbox');
+            const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+            const newState = !allChecked;
+
+            checkboxes.forEach(cb => {
+                cb.checked = newState;
+                const areaData = cb.dataset.area;
+                if (newState) {
+                    this.selectedAreas.add(areaData);
+                } else {
+                    this.selectedAreas.delete(areaData);
+                }
+            });
+
+            this.updateSelectionCount();
+        },
+
+        // Update selection count display
+        updateSelectionCount: function() {
+            const countEl = document.getElementById('selected-count');
+            const saveBtn = document.getElementById('save-selected-btn');
+            const selectAllBtn = document.getElementById('select-all-btn');
+
+            const count = this.selectedAreas.size;
+
+            if (countEl) {
+                countEl.textContent = count;
+            }
+
+            if (saveBtn) {
+                saveBtn.disabled = count === 0;
+            }
+
+            if (selectAllBtn) {
+                const totalCheckboxes = document.querySelectorAll('#areas-grid .area-checkbox').length;
+                const allSelected = count === totalCheckboxes && totalCheckboxes > 0;
+                selectAllBtn.textContent = allSelected ? 'Deselect All' : 'Select All';
+            }
+        },
+
+        // Save selected areas
+        saveSelectedAreas: function() {
+            if (this.selectedAreas.size === 0) {
+                this.showNotification('Please select at least one area', 'warning');
+                return;
+            }
+
+            if (this.isLoading) return;
+            this.isLoading = true;
+
+            const selectedAreasArray = Array.from(this.selectedAreas).map(areaDataStr => {
+                try {
+                    return JSON.parse(areaDataStr.replace(/&quot;/g, '"'));
+                } catch (e) {
+                    console.error('Error parsing area data:', e);
+                    return null;
+                }
+            }).filter(area => area !== null);
+
+            if (selectedAreasArray.length === 0) {
+                this.showNotification('Error processing selected areas', 'error');
+                this.isLoading = false;
+                return;
+            }
+
+            this.showLoadingState('Saving selected areas...');
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_save_selected_areas');
+            formData.append('selected_areas', JSON.stringify(selectedAreasArray));
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.showNotification(data.data.message || 'Areas saved successfully!', 'success');
+                    setTimeout(() => {
+                        location.reload();
+                    }, 1500);
+                } else {
+                    this.showNotification(data.data || 'Error saving areas', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                this.showNotification('Network error occurred', 'error');
+            })
+            .finally(() => {
+                this.hideLoadingState();
+                this.isLoading = false;
+            });
+        },
+
+        // Reset country selection
+        resetCountrySelection: function() {
+            if (!confirm('Are you sure? This will reset your country selection and remove all current areas.')) {
+                return;
+            }
+
+            this.showLoadingState('Resetting country selection...');
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_reset_service_country');
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.showNotification(data.data.message || 'Country reset successfully!', 'success');
+                    setTimeout(() => {
+                        location.reload();
+                    }, 1000);
+                } else {
+                    this.showNotification(data.data || 'Error resetting country', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                this.showNotification('Network error occurred', 'error');
+            })
+            .finally(() => {
+                this.hideLoadingState();
+            });
+        },
+
+        // Show add more areas interface
+        showAddMoreAreas: function() {
+            // Hide management view and show city search
+            const managementDiv = document.querySelector('.areas-management');
+            const cityDiv = document.querySelector('.first-city-container');
+
+            if (managementDiv) managementDiv.style.display = 'none';
+            if (cityDiv) {
+                cityDiv.style.display = 'block';
+                const cityInput = document.getElementById('city-search');
+                if (cityInput) {
+                    cityInput.value = '';
+                    cityInput.focus();
+                }
+            }
+        },
+
+        // Area Management Events
+        bindAreaManagementEvents: function() {
+            // These are handled in handleDocumentClick and handleDocumentChange
+            // This method is for any additional specific management events
+
+            // Update bulk action state on page load
+            this.updateBulkActionState();
+        },
+
+        // Handle status toggle
+        handleStatusToggle: function(e) {
+            const areaId = e.target.dataset.areaId;
+            if (!areaId) return;
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_toggle_area_status');
+            formData.append('area_id', areaId);
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.showNotification(data.data.message || 'Status updated successfully!', 'success');
+
+                    // Update the toggle label
+                    const label = e.target.parentNode.querySelector('.toggle-label');
+                    if (label) {
+                        label.textContent = data.data.new_status ? 'Active' : 'Inactive';
+                    }
+                } else {
+                    // Revert the toggle
+                    e.target.checked = !e.target.checked;
+                    this.showNotification(data.data || 'Error updating status', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                e.target.checked = !e.target.checked;
+                this.showNotification('Network error occurred', 'error');
+            });
+        },
+
+        // Handle delete area
+        handleDeleteArea: function(e) {
+            const deleteBtn = e.target.closest('.delete-area-btn');
+            const areaId = deleteBtn?.dataset.areaId;
+            const areaRow = deleteBtn?.closest('.area-row');
+            const areaNameEl = areaRow?.querySelector('.area-name strong');
+
+            if (!areaId || !areaRow || !areaNameEl) {
+                this.showNotification('Error: Could not identify area to delete', 'error');
+                return;
+            }
+
+            const areaName = areaNameEl.textContent;
+
+            if (!confirm(`Are you sure you want to delete "${areaName}"?`)) {
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_delete_area');
+            formData.append('area_id', areaId);
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.showNotification(data.data.message || 'Area deleted successfully!', 'success');
+                    areaRow.remove();
+                    this.updateBulkActionState();
+                } else {
+                    this.showNotification(data.data || 'Error deleting area', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                this.showNotification('Network error occurred', 'error');
+            });
+        },
+
+        // Handle edit area
+        handleEditArea: function(e) {
+            const editBtn = e.target.closest('.edit-area-btn');
+            const areaId = editBtn?.dataset.areaId;
+
+            if (!areaId) {
+                this.showNotification('Error: Could not identify area to edit', 'error');
+                return;
+            }
+
+            // For now, just show a message. You can implement edit functionality later
+            this.showNotification('Edit functionality coming soon!', 'info');
+        },
+
+        // Handle select all areas in management table
+        handleSelectAllAreas: function(checked) {
+            const checkboxes = document.querySelectorAll('.area-checkbox');
+            checkboxes.forEach(cb => {
+                cb.checked = checked;
+            });
+            this.updateBulkActionState();
+        },
+
+        // Get selected area IDs
+        getSelectedAreaIds: function() {
+            const checkedBoxes = document.querySelectorAll('.area-checkbox:checked');
+            return Array.from(checkedBoxes).map(cb => cb.value).filter(id => id);
+        },
+
+        // Update bulk action state
+        updateBulkActionState: function() {
+            const selectedIds = this.getSelectedAreaIds();
+            const bulkSelect = document.getElementById('bulk-action-select');
+            const applyBtn = document.getElementById('apply-bulk-action-btn');
+
+            if (applyBtn) {
+                applyBtn.disabled = !selectedIds.length || !bulkSelect?.value;
+            }
+
+            // Update select all checkbox
+            const selectAllCheckbox = document.getElementById('select-all-areas');
+            const allCheckboxes = document.querySelectorAll('.area-checkbox');
+
+            if (selectAllCheckbox && allCheckboxes.length > 0) {
+                const checkedCount = selectedIds.length;
+                selectAllCheckbox.checked = checkedCount === allCheckboxes.length;
+                selectAllCheckbox.indeterminate = checkedCount > 0 && checkedCount < allCheckboxes.length;
+            }
+        },
+
+        // Handle bulk action
+        handleBulkAction: function() {
+            const selectedIds = this.getSelectedAreaIds();
+            const bulkSelect = document.getElementById('bulk-action-select');
+            const action = bulkSelect?.value;
+
+            if (!selectedIds.length || !action) {
+                this.showNotification('Please select areas and an action', 'warning');
+                return;
+            }
+
+            const actionName = bulkSelect.selectedOptions[0].textContent;
+            if (!confirm(`Are you sure you want to ${actionName.toLowerCase()} ${selectedIds.length} areas?`)) {
+                return;
+            }
+
+            this.showLoadingState('Applying bulk action...');
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_bulk_area_action');
+            formData.append('area_ids', JSON.stringify(selectedIds));
+            formData.append('bulk_action', action);
+            formData.append('nonce', mobooking_area_vars.nonce || '');
+
+            fetch(mobooking_area_vars.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    this.showNotification(data.data.message || 'Bulk action completed successfully!', 'success');
+                    setTimeout(() => {
+                        location.reload();
+                    }, 1000);
+                } else {
+                    this.showNotification(data.data || 'Error applying bulk action', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                this.showNotification('Network error occurred', 'error');
+            })
+            .finally(() => {
+                this.hideLoadingState();
+            });
+        },
+
+        // Show search status
+        showSearchStatus: function() {
+            const statusDiv = document.getElementById('search-status');
+            if (statusDiv) {
+                statusDiv.style.display = 'block';
+            }
+        },
+
+        // Hide search status
+        hideSearchStatus: function() {
+            const statusDiv = document.getElementById('search-status');
+            if (statusDiv) {
+                statusDiv.style.display = 'none';
+            }
+        },
+
+        // Show loading state
+        showLoadingState: function(message) {
+            let overlay = document.getElementById('loading-overlay');
+            if (!overlay) {
+                overlay = document.createElement('div');
+                overlay.id = 'loading-overlay';
+                overlay.className = 'loading-overlay';
+                document.body.appendChild(overlay);
+            }
+
+            overlay.innerHTML = `
+                <div class="loading-content">
+                    <div class="loading-spinner"></div>
+                    <div class="loading-message">${this.escapeHtml(message)}</div>
+                </div>
+            `;
+            overlay.style.display = 'flex';
+        },
+
+        // Hide loading state
+        hideLoadingState: function() {
+            const overlay = document.getElementById('loading-overlay');
+            if (overlay) {
+                overlay.style.display = 'none';
+            }
+        },
+
+        // Show notification
+        showNotification: function(message, type = 'info') {
+            // Remove existing notifications of the same type
+            const existingNotifications = document.querySelectorAll(`.notification-${type}`);
+            existingNotifications.forEach(n => n.remove());
+
+            // Create notification element
+            const notification = document.createElement('div');
+            notification.className = `notification notification-${type}`;
+            notification.innerHTML = `
+                <div class="notification-content">
+                    <span class="notification-message">${this.escapeHtml(message)}</span>
+                    <button class="notification-close" type="button">&times;</button>
+                </div>
+            `;
+
+            // Add to page
+            document.body.appendChild(notification);
+
+            // Auto-remove after 5 seconds
+            setTimeout(() => {
+                if (notification.parentNode) {
+                    notification.remove();
+                }
+            }, 5000);
+
+            // Animate in
+            requestAnimationFrame(() => {
+                notification.classList.add('notification-show');
+            });
+        },
+
+        // Escape HTML
+        escapeHtml: function(text) {
+            if (typeof text !== 'string') {
+                return '';
+            }
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+    };
+
+    // Initialize the areas manager
+    try {
+        EnhancedAreasManager.init();
+    } catch (error) {
+        console.error('Error initializing Enhanced Areas Manager:', error);
+    }
+
+    // Make it globally available for debugging
+    window.EnhancedAreasManager = EnhancedAreasManager;
+});
+</script>
+<style>
+/* Enhanced Areas Styles with Local JSON Support */
+.areas-section {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.areas-header {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 30px;
+    border-radius: 12px;
+    margin-bottom: 30px;
+}
+
+.areas-header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.areas-title-group h1 {
+    margin: 0 0 5px 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.title-icon {
+    width: 28px;
+    height: 28px;
+}
+
+.areas-subtitle {
+    margin: 0;
+    opacity: 0.9;
+    font-size: 16px;
+}
+
+.areas-stats {
+    display: flex;
+    gap: 30px;
+}
+
+.stat-item {
+    text-align: center;
+}
+
+.stat-number {
+    display: block;
+    font-size: 28px;
+    font-weight: bold;
+    line-height: 1;
+}
+
+.stat-label {
+    font-size: 14px;
+    opacity: 0.8;
+}
+
+/* Country Selection */
+.country-selection-card, .first-city-card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+    padding: 40px;
+    text-align: center;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.selection-icon {
+    width: 60px;
+    height: 60px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 20px;
+}
+
+.selection-icon svg {
+    width: 30px;
+    height: 30px;
+    color: white;
+}
+
+.selection-header h2 {
+    margin: 0 0 15px 0;
+    color: #333;
+}
+
+.selection-header p {
+    color: #666;
+    line-height: 1.6;
+    margin-bottom: 30px;
+}
+
+/* Data Quality Badges */
+.data-quality-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 500;
+    margin-top: 15px;
+}
+
+.data-quality-badge.local-data {
+    background: #e8f5e8;
+    color: #2d5a2d;
+    border: 1px solid #a5d6a5;
+}
+
+.data-quality-badge.api-data {
+    background: #e6f3ff;
+    color: #1f4d73;
+    border: 1px solid #99c9ff;
+}
+
+.badge-icon {
+    font-size: 16px;
+}
+
+/* Data Source Info */
+.data-source-info {
+    margin-top: 20px;
+    text-align: left;
+}
+
+.data-source-info .info-card {
+    padding: 20px;
+    border-radius: 8px;
+    border-left: 4px solid;
+}
+
+.data-source-info.local-data .info-card {
+    background: #f0f9f0;
+    border-left-color: #4caf50;
+}
+
+.data-source-info.api-data .info-card {
+    background: #f0f8ff;
+    border-left-color: #2196f3;
+}
+
+.info-card h4 {
+    margin: 0 0 10px 0;
+    color: #333;
+}
+
+.info-card p {
+    margin: 0;
+    color: #666;
+    line-height: 1.5;
+}
+
+/* Form Elements */
+.form-group {
+    margin-bottom: 25px;
+    text-align: left;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 500;
+    color: #333;
+}
+
+.country-dropdown, .city-search-input {
+    width: 100%;
+    padding: 12px 16px;
+    border: 2px solid #e1e5e9;
+    border-radius: 8px;
+    font-size: 16px;
+    transition: border-color 0.3s;
+}
+
+.country-dropdown:focus, .city-search-input:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.field-help {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #666;
+}
+
+/* Search Input Group */
+.search-input-group {
+    position: relative;
+}
+
+.search-btn {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.search-btn:hover {
+    background: #5a6fd8;
+}
+
+.search-btn svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Buttons */
+.btn-primary, .btn-secondary, .btn-outline {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.3s;
+    font-size: 16px;
+    border: 2px solid transparent;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+.btn-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.btn-secondary {
+    background: #f8f9fa;
+    color: #495057;
+    border-color: #dee2e6;
+}
+
+.btn-secondary:hover {
+    background: #e9ecef;
+}
+
+.btn-outline {
+    background: transparent;
+    color: #667eea;
+    border-color: #667eea;
+}
+
+.btn-outline:hover {
+    background: #667eea;
+    color: white;
+}
+
+/* Areas Results */
+.areas-results {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+    padding: 30px;
+    margin-top: 30px;
+}
+
+.results-header {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.results-header h3 {
+    margin: 0 0 10px 0;
+    color: #333;
+}
+
+.results-subtitle {
+    color: #666;
+    margin: 0;
+}
+
+/* Areas Grid */
+.areas-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.area-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 20px;
+    border: 2px solid #e1e5e9;
+    border-radius: 8px;
+    transition: all 0.3s;
+    cursor: pointer;
+}
+
+.area-item:hover {
+    border-color: #667eea;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+}
+
+.area-item input[type="checkbox"] {
+    margin-top: 2px;
+}
+
+.area-content {
+    flex: 1;
+}
+
+.area-name {
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 8px;
+}
+
+.area-details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.zip-code {
+    background: #e3f2fd;
+    color: #1976d2;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.area-state {
+    background: #f3e5f5;
+    color: #7b1fa2;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.data-source {
+    background: #e8f5e8;
+    color: #388e3c;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.area-coordinates {
+    font-size: 12px;
+    color: #666;
+}
+
+/* Selection Actions */
+.selection-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 20px;
+    border-top: 1px solid #e1e5e9;
+}
+
+.selection-info {
+    font-weight: 500;
+    color: #333;
+}
+
+.action-buttons {
+    display: flex;
+    gap: 12px;
+}
+
+/* Areas Management */
+.management-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+.header-content h2 {
+    margin: 0 0 5px 0;
+    color: #333;
+}
+
+.data-source-indicator .indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 16px;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.indicator.local-data {
+    background: #e8f5e8;
+    color: #2d5a2d;
+}
+
+.indicator.api-data {
+    background: #e6f3ff;
+    color: #1f4d73;
+}
+
+.header-actions {
+    display: flex;
+    gap: 12px;
+}
+
+/* Areas Table */
+.areas-table-container {
+    background: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    margin-bottom: 20px;
+}
+
+.areas-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.areas-table th,
+.areas-table td {
+    padding: 16px;
+    text-align: left;
+    border-bottom: 1px solid #e1e5e9;
+}
+
+.areas-table th {
+    background: #f8f9fa;
+    font-weight: 600;
+    color: #495057;
+}
+
+.areas-table tbody tr:hover {
+    background: #f8f9fa;
+}
+
+/* Status Toggle */
+.status-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+}
+
+.toggle-slider {
+    position: relative;
+    width: 40px;
+    height: 20px;
+    background: #ccc;
+    border-radius: 20px;
+    transition: background-color 0.3s;
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    background: white;
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.3s;
+}
+
+.status-toggle input:checked + .toggle-slider {
+    background: #4caf50;
+}
+
+.status-toggle input:checked + .toggle-slider::before {
+    transform: translateX(20px);
+}
+
+.status-toggle input {
+    display: none;
+}
+
+/* Action Buttons */
+.btn-icon {
+    background: none;
+    border: none;
+    padding: 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.btn-icon:hover {
+    background: #f8f9fa;
+}
+
+.btn-icon svg {
+    width: 16px;
+    height: 16px;
+    color: #666;
+}
+
+.delete-area-btn:hover svg {
+    color: #dc3545;
+}
+
+/* Bulk Actions */
+.bulk-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    background: #f8f9fa;
+    border-radius: 8px;
+}
+
+.bulk-actions-left {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.areas-count {
+    color: #666;
+    font-size: 14px;
+}
+
+/* Search Status */
+.search-status {
+    padding: 20px;
+    text-align: center;
+    background: #f8f9fa;
+    border-radius: 8px;
+    margin-top: 20px;
+}
+
+.status-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+}
+
+.status-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #e1e5e9;
+    border-top-color: #667eea;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Loading Overlay */
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.loading-content {
+    background: white;
+    padding: 40px;
+    border-radius: 12px;
+    text-align: center;
+    max-width: 300px;
+}
+
+.loading-spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #e1e5e9;
+    border-top-color: #667eea;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 20px;
+}
+
+.loading-message {
+    color: #333;
+    font-weight: 500;
+}
+
+/* Notifications */
+.notification {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+    z-index: 10000;
+    transform: translateX(400px);
+    transition: transform 0.3s;
+    min-width: 300px;
+    max-width: 500px;
+}
+
+.notification-show {
+    transform: translateX(0);
+}
+
+.notification-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+}
+
+.notification-success {
+    border-left: 4px solid #4caf50;
+}
+
+.notification-error {
+    border-left: 4px solid #f44336;
+}
+
+.notification-warning {
+    border-left: 4px solid #ff9800;
+}
+
+.notification-info {
+    border-left: 4px solid #2196f3;
+}
+
+.notification-close {
+    background: none;
+    border: none;
+    font-size: 18px;
+    color: #666;
+    cursor: pointer;
+    padding: 0;
+    margin-left: 12px;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .areas-header-content {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .areas-stats {
+        justify-content: center;
+    }
+
+    .management-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .header-actions {
+        justify-content: center;
+    }
+
+    .areas-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .selection-actions {
+        flex-direction: column;
+        gap: 16px;
+        align-items: stretch;
+    }
+
+    .bulk-actions {
+        flex-direction: column;
+        gap: 16px;
+        align-items: stretch;
+    }
+
+    .areas-table-container {
+        overflow-x: auto;
+    }
+
+    .notification {
+        right: 10px;
+        left: 10px;
+        max-width: none;
+        transform: translateY(-100px);
+    }
+
+    .notification-show {
+        transform: translateY(0);
+    }
+}
+</style>

--- a/page-booking-form.php
+++ b/page-booking-form.php
@@ -1,0 +1,1534 @@
+<?php
+// dashboard/sections/booking-form.php - Enhanced Booking Form Management
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Initialize booking form manager
+$booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
+$settings = $booking_form_manager->get_settings($user_id);
+$booking_url = $booking_form_manager->get_booking_form_url($user_id);
+$embed_url = $booking_form_manager->get_embed_url($user_id);
+
+// Get user's services count for validation
+$services_manager = new \MoBooking\Services\ServicesManager();
+$services = $services_manager->get_user_services($user_id);
+$services_count = count($services);
+
+// Get geography areas count
+$geography_manager = new \MoBooking\Geography\Manager();
+$areas = $geography_manager->get_user_areas($user_id);
+$areas_count = count($areas);
+
+// Check if form can be published
+$can_publish = ($services_count > 0 && $areas_count > 0);
+
+// Get metrics (you can implement these functions in your Manager classes)
+$total_bookings = 247; // Replace with actual data: $booking_form_manager->get_total_bookings($user_id);
+$form_views = 1432; // Replace with actual data: $booking_form_manager->get_form_views($user_id);
+$conversion_rate = 17.2; // Replace with actual data: $booking_form_manager->get_conversion_rate($user_id);
+$monthly_change = 12; // Replace with actual data
+
+// Calculate setup progress
+$setup_steps = [
+    'services' => $services_count > 0,
+    'areas' => $areas_count > 0,
+    'design' => !empty($settings->primary_color) && !empty($settings->form_title),
+    'seo' => !empty($settings->seo_title) && !empty($settings->seo_description)
+];
+$completed_steps = count(array_filter($setup_steps));
+$total_steps = count($setup_steps);
+$progress_percentage = round(($completed_steps / $total_steps) * 100);
+?>
+
+<style>
+/* Enhanced CSS Variables & Base Styles */
+:root {
+    --mo-primary: #3b82f6;
+    --mo-primary-dark: #1e40af;
+    --mo-secondary: #f1f5f9;
+    --mo-success: #10b981;
+    --mo-warning: #f59e0b;
+    --mo-danger: #ef4444;
+    --mo-info: #06b6d4;
+    --mo-border: #e2e8f0;
+    --mo-text: #1e293b;
+    --mo-text-muted: #64748b;
+    --mo-background: #ffffff;
+    --mo-card-bg: #ffffff;
+    --mo-hover-bg: #f8fafc;
+    --mo-radius: 8px;
+    --mo-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+    --mo-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+    --mo-transition: all 0.2s ease;
+}
+
+.mobooking-dashboard * {
+    box-sizing: border-box;
+}
+
+/* Dashboard Header with Quick Actions */
+.mobooking-dashboard .dashboard-header {
+    background: var(--mo-card-bg);
+    border-radius: var(--mo-radius);
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: var(--mo-shadow);
+    border: 1px solid var(--mo-border);
+}
+
+.mobooking-dashboard .header-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.mobooking-dashboard .header-title-section {
+    flex: 1;
+}
+
+.mobooking-dashboard .header-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 0.5rem 0;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--mo-text);
+}
+
+.mobooking-dashboard .title-icon {
+    width: 2rem;
+    height: 2rem;
+    color: var(--mo-primary);
+}
+
+.mobooking-dashboard .header-subtitle {
+    margin: 0;
+    color: var(--mo-text-muted);
+    font-size: 1.1rem;
+}
+
+.mobooking-dashboard .header-actions {
+    display: flex;
+    gap: 1rem;
+    flex-shrink: 0;
+}
+
+.mobooking-dashboard .btn-open-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.875rem 1.5rem;
+    background: linear-gradient(135deg, var(--mo-primary), var(--mo-primary-dark));
+    color: white;
+    border: none;
+    border-radius: var(--mo-radius);
+    font-weight: 600;
+    text-decoration: none;
+    transition: var(--mo-transition);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.mobooking-dashboard .btn-open-form:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(59, 130, 246, 0.4);
+    color: white;
+    text-decoration: none;
+}
+
+.mobooking-dashboard .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.875rem 1.25rem;
+    background: var(--mo-secondary);
+    color: var(--mo-text);
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    font-weight: 500;
+    text-decoration: none;
+    transition: var(--mo-transition);
+    cursor: pointer;
+}
+
+.mobooking-dashboard .btn-secondary:hover {
+    background: var(--mo-hover-bg);
+    border-color: var(--mo-primary);
+    color: var(--mo-text);
+    text-decoration: none;
+}
+
+/* Setup Progress */
+.mobooking-dashboard .setup-progress {
+    background: var(--mo-card-bg);
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: var(--mo-shadow);
+}
+
+.mobooking-dashboard .progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.mobooking-dashboard .progress-title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--mo-text);
+}
+
+.mobooking-dashboard .progress-percentage {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--mo-primary);
+}
+
+.mobooking-dashboard .progress-bar-container {
+    background: var(--mo-secondary);
+    border-radius: 999px;
+    height: 8px;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+}
+
+.mobooking-dashboard .progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--mo-primary), var(--mo-primary-dark));
+    border-radius: 999px;
+    transition: width 0.5s ease;
+}
+
+.mobooking-dashboard .setup-steps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+.mobooking-dashboard .setup-step {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    background: var(--mo-background);
+    transition: var(--mo-transition);
+}
+
+.mobooking-dashboard .setup-step:hover {
+    background: var(--mo-hover-bg);
+}
+
+.mobooking-dashboard .setup-step.completed {
+    background: rgba(16, 185, 129, 0.05);
+    border-color: var(--mo-success);
+}
+
+.mobooking-dashboard .setup-step.incomplete {
+    background: rgba(245, 158, 11, 0.05);
+    border-color: var(--mo-warning);
+}
+
+.mobooking-dashboard .step-icon {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    flex-shrink: 0;
+}
+
+.mobooking-dashboard .step-icon.completed {
+    background: var(--mo-success);
+}
+
+.mobooking-dashboard .step-icon.incomplete {
+    background: var(--mo-warning);
+}
+
+.mobooking-dashboard .step-content {
+    flex: 1;
+}
+
+.mobooking-dashboard .step-title {
+    margin: 0 0 0.25rem 0;
+    font-weight: 600;
+    color: var(--mo-text);
+}
+
+.mobooking-dashboard .step-description {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--mo-text-muted);
+}
+
+/* Settings Container */
+.mobooking-dashboard .settings-container {
+    background: var(--mo-card-bg);
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    box-shadow: var(--mo-shadow);
+    overflow: hidden;
+}
+
+/* Enhanced Tabs */
+.mobooking-dashboard .settings-tabs {
+    display: flex;
+    background: var(--mo-secondary);
+    border-bottom: 1px solid var(--mo-border);
+    overflow-x: auto;
+}
+
+.mobooking-dashboard .tab-button {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1.25rem 1.5rem;
+    border: none;
+    background: transparent;
+    color: var(--mo-text-muted);
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--mo-transition);
+    border-bottom: 3px solid transparent;
+    white-space: nowrap;
+    min-width: fit-content;
+}
+
+.mobooking-dashboard .tab-button:hover {
+    background: var(--mo-hover-bg);
+    color: var(--mo-text);
+}
+
+.mobooking-dashboard .tab-button.active {
+    background: var(--mo-card-bg);
+    color: var(--mo-primary);
+    border-bottom-color: var(--mo-primary);
+}
+
+.mobooking-dashboard .tab-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+/* Form Content */
+.mobooking-dashboard .form-content {
+    padding: 2rem;
+}
+
+.mobooking-dashboard .tab-content {
+    display: none;
+}
+
+.mobooking-dashboard .tab-content.active {
+    display: block;
+    animation: moFadeIn 0.3s ease;
+}
+
+@keyframes moFadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.mobooking-dashboard .content-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+/* Settings Groups */
+.mobooking-dashboard .settings-group {
+    background: var(--mo-background);
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    padding: 1.5rem;
+    box-shadow: var(--mo-shadow);
+}
+
+.mobooking-dashboard .group-header {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--mo-border);
+}
+
+.mobooking-dashboard .group-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--mo-text);
+}
+
+.mobooking-dashboard .group-description {
+    margin: 0;
+    color: var(--mo-text-muted);
+}
+
+/* Form Fields */
+.mobooking-dashboard .form-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.mobooking-dashboard .field-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.mobooking-dashboard .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.mobooking-dashboard .field-label {
+    font-weight: 600;
+    color: var(--mo-text);
+    font-size: 0.875rem;
+}
+
+.mobooking-dashboard .field-label.required::after {
+    content: " *";
+    color: var(--mo-danger);
+}
+
+.mobooking-dashboard .form-control {
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    font-size: 0.875rem;
+    background: var(--mo-background);
+    color: var(--mo-text);
+    transition: var(--mo-transition);
+    width: 100%;
+}
+
+.mobooking-dashboard .form-control:focus {
+    outline: none;
+    border-color: var(--mo-primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.mobooking-dashboard .field-note {
+    font-size: 0.75rem;
+    color: var(--mo-text-muted);
+}
+
+/* Color Picker */
+.mobooking-dashboard .color-input-group {
+    display: flex;
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    overflow: hidden;
+    background: var(--mo-background);
+}
+
+.mobooking-dashboard .color-picker {
+    width: 3rem;
+    height: 2.5rem;
+    border: none;
+    cursor: pointer;
+}
+
+.mobooking-dashboard .color-text {
+    flex: 1;
+    border: none;
+    padding: 0.5rem;
+    font-family: monospace;
+    background: transparent;
+}
+
+/* Checkbox Options */
+.mobooking-dashboard .checkbox-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+}
+
+.mobooking-dashboard .checkbox-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+    border: 1px solid var(--mo-border);
+    border-radius: var(--mo-radius);
+    background: var(--mo-background);
+    cursor: pointer;
+    transition: var(--mo-transition);
+}
+
+.mobooking-dashboard .checkbox-option:hover {
+    background: var(--mo-hover-bg);
+    border-color: var(--mo-primary);
+}
+
+.mobooking-dashboard .checkbox-option input[type="checkbox"] {
+    margin: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    accent-color: var(--mo-primary);
+}
+
+.mobooking-dashboard .checkbox-content {
+    flex: 1;
+}
+
+.mobooking-dashboard .checkbox-title {
+    font-weight: 600;
+    color: var(--mo-text);
+    margin-bottom: 0.25rem;
+}
+
+.mobooking-dashboard .checkbox-desc {
+    font-size: 0.875rem;
+    color: var(--mo-text-muted);
+}
+
+/* Action Buttons */
+.mobooking-dashboard .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    padding: 1.5rem 2rem;
+    background: var(--mo-secondary);
+    border-top: 1px solid var(--mo-border);
+}
+
+.mobooking-dashboard .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.875rem 1.5rem;
+    background: var(--mo-primary);
+    color: white;
+    border: none;
+    border-radius: var(--mo-radius);
+    font-weight: 600;
+    cursor: pointer;
+    transition: var(--mo-transition);
+    text-decoration: none;
+}
+
+.mobooking-dashboard .btn-primary:hover {
+    background: var(--mo-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+/* Notification */
+.mobooking-dashboard .notification {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 1rem 1.5rem;
+    border-radius: var(--mo-radius);
+    box-shadow: var(--mo-shadow-lg);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 500;
+    animation: moSlideIn 0.3s ease;
+}
+
+.mobooking-dashboard .notification.success {
+    background: var(--mo-success);
+    color: white;
+}
+
+.mobooking-dashboard .notification.error {
+    background: var(--mo-danger);
+    color: white;
+}
+
+.mobooking-dashboard .notification-close {
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 1.25rem;
+    cursor: pointer;
+    opacity: 0.8;
+}
+
+.mobooking-dashboard .notification-close:hover {
+    opacity: 1;
+}
+
+@keyframes moSlideIn {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .mobooking-dashboard .header-top {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .mobooking-dashboard .header-actions {
+        width: 100%;
+        justify-content: stretch;
+    }
+
+    .mobooking-dashboard .header-actions a,
+    .mobooking-dashboard .header-actions button {
+        flex: 1;
+        justify-content: center;
+    }
+
+    .mobooking-dashboard .metrics-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .mobooking-dashboard .setup-steps {
+        grid-template-columns: 1fr;
+    }
+
+    .mobooking-dashboard .settings-tabs {
+        flex-direction: column;
+    }
+
+    .mobooking-dashboard .tab-button {
+        justify-content: flex-start;
+        border-bottom: none;
+        border-left: 3px solid transparent;
+    }
+
+    .mobooking-dashboard .tab-button.active {
+        border-bottom: none;
+        border-left-color: var(--mo-primary);
+    }
+
+    .mobooking-dashboard .field-row {
+        grid-template-columns: 1fr;
+    }
+
+    .mobooking-dashboard .form-actions {
+        flex-direction: column;
+    }
+}
+
+/* Loading States */
+.mobooking-dashboard .loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.mobooking-dashboard .spinner {
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid transparent;
+    border-top: 2px solid currentColor;
+    border-radius: 50%;
+    animation: moSpin 1s linear infinite;
+}
+
+@keyframes moSpin {
+    to { transform: rotate(360deg); }
+}
+</style>
+
+<div class="mobooking-dashboard">
+    <!-- Dashboard Header -->
+    <div class="dashboard-header">
+        <div class="header-top">
+            <div class="header-title-section">
+                <h1 class="header-title">
+                    <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+                        <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+                    </svg>
+                    <?php _e('Booking Form Dashboard', 'mobooking'); ?>
+                </h1>
+                <p class="header-subtitle"><?php _e('Create and customize your customer booking experience', 'mobooking'); ?></p>
+            </div>
+
+            <div class="header-actions">
+                <a href="<?php echo esc_url($booking_url); ?>" target="_blank" class="btn-open-form" id="open-form-btn">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                        <polyline points="15,3 21,3 21,9"/>
+                        <line x1="10" y1="14" x2="21" y2="3"/>
+                    </svg>
+                    <?php _e('Open Form', 'mobooking'); ?>
+                </a>
+                <button class="btn-secondary" id="preview-btn">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                        <circle cx="12" cy="12" r="3"/>
+                    </svg>
+                    <?php _e('Preview', 'mobooking'); ?>
+                </button>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- Setup Progress -->
+    <div class="setup-progress">
+        <div class="progress-bar-container">
+            <div class="progress-bar" style="width: <?php echo $progress_percentage; ?>%"></div>
+        </div>
+
+        <div class="setup-steps">
+            <div class="setup-step <?php echo $setup_steps['services'] ? 'completed' : 'incomplete'; ?>">
+                <div class="step-icon <?php echo $setup_steps['services'] ? 'completed' : 'incomplete'; ?>">
+                    <?php if ($setup_steps['services']): ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="20,6 9,17 4,12"/>
+                        </svg>
+                    <?php else: ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <path d="M12 6v6l4 2"/>
+                        </svg>
+                    <?php endif; ?>
+                </div>
+                <div class="step-content">
+                    <h4 class="step-title"><?php _e('Services Added', 'mobooking'); ?></h4>
+                    <p class="step-description">
+                        <?php
+                        if ($setup_steps['services']) {
+                            printf(__('%d services configured and active', 'mobooking'), $services_count);
+                        } else {
+                            _e('Add your first service to get started', 'mobooking');
+                        }
+                        ?>
+                    </p>
+                </div>
+            </div>
+
+            <div class="setup-step <?php echo $setup_steps['areas'] ? 'completed' : 'incomplete'; ?>">
+                <div class="step-icon <?php echo $setup_steps['areas'] ? 'completed' : 'incomplete'; ?>">
+                    <?php if ($setup_steps['areas']): ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="20,6 9,17 4,12"/>
+                        </svg>
+                    <?php else: ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <path d="M12 6v6l4 2"/>
+                        </svg>
+                    <?php endif; ?>
+                </div>
+                <div class="step-content">
+                    <h4 class="step-title"><?php _e('Service Areas', 'mobooking'); ?></h4>
+                    <p class="step-description">
+                        <?php
+                        if ($setup_steps['areas']) {
+                            printf(__('%d geographic areas defined', 'mobooking'), $areas_count);
+                        } else {
+                            _e('Define where you provide services', 'mobooking');
+                        }
+                        ?>
+                    </p>
+                </div>
+            </div>
+
+            <div class="setup-step <?php echo $setup_steps['design'] ? 'completed' : 'incomplete'; ?>">
+                <div class="step-icon <?php echo $setup_steps['design'] ? 'completed' : 'incomplete'; ?>">
+                    <?php if ($setup_steps['design']): ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="20,6 9,17 4,12"/>
+                        </svg>
+                    <?php else: ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <path d="M12 6v6l4 2"/>
+                        </svg>
+                    <?php endif; ?>
+                </div>
+                <div class="step-content">
+                    <h4 class="step-title"><?php _e('Form Design', 'mobooking'); ?></h4>
+                    <p class="step-description">
+                        <?php
+                        if ($setup_steps['design']) {
+                            _e('Branding and colors customized', 'mobooking');
+                        } else {
+                            _e('Customize your form appearance', 'mobooking');
+                        }
+                        ?>
+                    </p>
+                </div>
+            </div>
+
+            <div class="setup-step <?php echo $setup_steps['seo'] ? 'completed' : 'incomplete'; ?>">
+                <div class="step-icon <?php echo $setup_steps['seo'] ? 'completed' : 'incomplete'; ?>">
+                    <?php if ($setup_steps['seo']): ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="20,6 9,17 4,12"/>
+                        </svg>
+                    <?php else: ?>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <path d="M12 6v6l4 2"/>
+                        </svg>
+                    <?php endif; ?>
+                </div>
+                <div class="step-content">
+                    <h4 class="step-title"><?php _e('SEO Optimization', 'mobooking'); ?></h4>
+                    <p class="step-description">
+                        <?php
+                        if ($setup_steps['seo']) {
+                            _e('SEO title and description added', 'mobooking');
+                        } else {
+                            _e('Add meta description and title', 'mobooking');
+                        }
+                        ?>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Settings Container -->
+    <div class="settings-container">
+        <div class="settings-tabs">
+            <button type="button" class="tab-button active" data-tab="general">
+                <svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="12" cy="12" r="3"/>
+                    <path d="M12 1v6m0 6v6m11-7h-6m-6 0H1"/>
+                </svg>
+                <?php _e('General', 'mobooking'); ?>
+            </button>
+            <button type="button" class="tab-button" data-tab="design">
+                <svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+                    <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+                </svg>
+                <?php _e('Design', 'mobooking'); ?>
+            </button>
+            <button type="button" class="tab-button" data-tab="advanced">
+                <svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+                    <circle cx="12" cy="12" r="3"/>
+                </svg>
+                <?php _e('Advanced', 'mobooking'); ?>
+            </button>
+            <button type="button" class="tab-button" data-tab="share">
+                <svg class="tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
+                    <polyline points="16,6 12,2 8,6"/>
+                    <line x1="12" y1="2" x2="12" y2="15"/>
+                </svg>
+                <?php _e('Share & Embed', 'mobooking'); ?>
+            </button>
+        </div>
+
+        <form id="booking-form-settings" method="post">
+            <?php wp_nonce_field('mobooking-booking-form-nonce', 'nonce'); ?>
+
+            <div class="form-content">
+                <!-- General Tab -->
+                <div class="tab-content active" data-tab="general">
+                    <div class="content-grid">
+                        <!-- Basic Information -->
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('Basic Information', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Configure the basic details of your booking form', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="form-group">
+                                    <label for="form-title" class="field-label required"><?php _e('Form Title', 'mobooking'); ?></label>
+                                    <input type="text" id="form-title" name="form_title" class="form-control"
+                                           value="<?php echo esc_attr($settings->form_title); ?>" required>
+                                    <small class="field-note"><?php _e('This appears as the main heading on your booking form', 'mobooking'); ?></small>
+                                </div>
+
+                                <div class="form-group">
+                                    <label for="form-description" class="field-label"><?php _e('Form Description', 'mobooking'); ?></label>
+                                    <textarea id="form-description" name="form_description" class="form-control" rows="3"
+                                              placeholder="<?php _e('Book our professional services quickly and easily...', 'mobooking'); ?>"><?php echo esc_textarea($settings->form_description); ?></textarea>
+                                    <small class="field-note"><?php _e('Brief description shown below the title', 'mobooking'); ?></small>
+                                </div>
+
+                                <div class="field-row">
+                                    <div class="form-group">
+                                        <label for="language" class="field-label"><?php _e('Language', 'mobooking'); ?></label>
+                                        <select id="language" name="language" class="form-control">
+                                            <option value="en" <?php selected($settings->language, 'en'); ?>><?php _e('English', 'mobooking'); ?></option>
+                                            <option value="es" <?php selected($settings->language, 'es'); ?>><?php _e('Spanish', 'mobooking'); ?></option>
+                                            <option value="fr" <?php selected($settings->language, 'fr'); ?>><?php _e('French', 'mobooking'); ?></option>
+                                            <option value="de" <?php selected($settings->language, 'de'); ?>><?php _e('German', 'mobooking'); ?></option>
+                                            <option value="it" <?php selected($settings->language, 'it'); ?>><?php _e('Italian', 'mobooking'); ?></option>
+                                        </select>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <label for="is-active" class="field-label"><?php _e('Form Status', 'mobooking'); ?></label>
+                                        <select id="is-active" name="is_active" class="form-control">
+                                            <option value="1" <?php selected($settings->is_active, 1); ?>><?php _e('Active', 'mobooking'); ?></option>
+                                            <option value="0" <?php selected($settings->is_active, 0); ?>><?php _e('Inactive', 'mobooking'); ?></option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Form Features -->
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('Form Features', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Enable or disable specific features in your booking form', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="checkbox-grid">
+                                    <div class="checkbox-option">
+                                        <input type="checkbox" id="show-form-header" name="show_form_header" value="1"
+                                               <?php checked($settings->show_form_header, 1); ?>>
+                                        <div class="checkbox-content">
+                                            <div class="checkbox-title"><?php _e('Show Form Header', 'mobooking'); ?></div>
+                                            <div class="checkbox-desc"><?php _e('Display title, description, and logo at the top', 'mobooking'); ?></div>
+                                        </div>
+                                    </div>
+
+                                    <div class="checkbox-option">
+                                        <input type="checkbox" id="show-service-descriptions" name="show_service_descriptions" value="1"
+                                               <?php checked($settings->show_service_descriptions, 1); ?>>
+                                        <div class="checkbox-content">
+                                            <div class="checkbox-title"><?php _e('Show Service Descriptions', 'mobooking'); ?></div>
+                                            <div class="checkbox-desc"><?php _e('Display detailed descriptions for each service', 'mobooking'); ?></div>
+                                        </div>
+                                    </div>
+
+                                    <div class="checkbox-option">
+                                        <input type="checkbox" id="show-price-breakdown" name="show_price_breakdown" value="1"
+                                               <?php checked($settings->show_price_breakdown, 1); ?>>
+                                        <div class="checkbox-content">
+                                            <div class="checkbox-title"><?php _e('Show Price Breakdown', 'mobooking'); ?></div>
+                                            <div class="checkbox-desc"><?php _e('Display detailed pricing information', 'mobooking'); ?></div>
+                                        </div>
+                                    </div>
+
+                                    <div class="checkbox-option">
+                                        <input type="checkbox" id="enable-zip-validation" name="enable_zip_validation" value="1"
+                                               <?php checked($settings->enable_zip_validation, 1); ?>>
+                                        <div class="checkbox-content">
+                                            <div class="checkbox-title"><?php _e('ZIP Code Validation', 'mobooking'); ?></div>
+                                            <div class="checkbox-desc"><?php _e('Validate ZIP codes for service area coverage', 'mobooking'); ?></div>
+                                        </div>
+                                    </div>
+
+                                    <div class="checkbox-option">
+                                        <input type="checkbox" id="show-form-footer" name="show_form_footer" value="1"
+                                               <?php checked($settings->show_form_footer, 1); ?>>
+                                        <div class="checkbox-content">
+                                            <div class="checkbox-title"><?php _e('Show Form Footer', 'mobooking'); ?></div>
+                                            <div class="checkbox-desc"><?php _e('Display footer content and social links', 'mobooking'); ?></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Design Tab -->
+                <div class="tab-content" data-tab="design">
+                    <div class="content-grid">
+                        <!-- Branding & Colors -->
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('Branding & Colors', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Customize the visual appearance of your booking form', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="field-row">
+                                    <div class="form-group">
+                                        <label for="primary-color" class="field-label"><?php _e('Primary Color', 'mobooking'); ?></label>
+                                        <div class="color-input-group">
+                                            <input type="color" id="primary-color" name="primary_color"
+                                                   value="<?php echo esc_attr($settings->primary_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->primary_color); ?>" readonly>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <label for="secondary-color" class="field-label"><?php _e('Secondary Color', 'mobooking'); ?></label>
+                                        <div class="color-input-group">
+                                            <input type="color" id="secondary-color" name="secondary_color"
+                                                   value="<?php echo esc_attr($settings->secondary_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->secondary_color); ?>" readonly>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="field-row">
+                                    <div class="form-group">
+                                        <label for="background-color" class="field-label"><?php _e('Background Color', 'mobooking'); ?></label>
+                                        <div class="color-input-group">
+                                            <input type="color" id="background-color" name="background_color"
+                                                   value="<?php echo esc_attr($settings->background_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->background_color); ?>" readonly>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <label for="text-color" class="field-label"><?php _e('Text Color', 'mobooking'); ?></label>
+                                        <div class="color-input-group">
+                                            <input type="color" id="text-color" name="text_color"
+                                                   value="<?php echo esc_attr($settings->text_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->text_color); ?>" readonly>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Layout & Style -->
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('Layout & Style', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Adjust the layout and presentation of your form', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="field-row">
+                                    <div class="form-group">
+                                        <label for="form-layout" class="field-label"><?php _e('Form Layout', 'mobooking'); ?></label>
+                                        <select id="form-layout" name="form_layout" class="form-control">
+                                            <option value="modern" <?php selected($settings->form_layout, 'modern'); ?>><?php _e('Modern', 'mobooking'); ?></option>
+                                            <option value="classic" <?php selected($settings->form_layout, 'classic'); ?>><?php _e('Classic', 'mobooking'); ?></option>
+                                            <option value="minimal" <?php selected($settings->form_layout, 'minimal'); ?>><?php _e('Minimal', 'mobooking'); ?></option>
+                                        </select>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <label for="form-width" class="field-label"><?php _e('Form Width', 'mobooking'); ?></label>
+                                        <select id="form-width" name="form_width" class="form-control">
+                                            <option value="narrow" <?php selected($settings->form_width, 'narrow'); ?>><?php _e('Narrow (600px)', 'mobooking'); ?></option>
+                                            <option value="standard" <?php selected($settings->form_width, 'standard'); ?>><?php _e('Standard (800px)', 'mobooking'); ?></option>
+                                            <option value="wide" <?php selected($settings->form_width, 'wide'); ?>><?php _e('Wide (1000px)', 'mobooking'); ?></option>
+                                            <option value="full" <?php selected($settings->form_width, 'full'); ?>><?php _e('Full Width', 'mobooking'); ?></option>
+                                        </select>
+                                    </div>
+                                </div>
+
+                                <div class="field-row">
+                                    <div class="form-group">
+                                        <label for="step-indicator-style" class="field-label"><?php _e('Step Indicator Style', 'mobooking'); ?></label>
+                                        <select id="step-indicator-style" name="step_indicator_style" class="form-control">
+                                            <option value="progress" <?php selected($settings->step_indicator_style, 'progress'); ?>><?php _e('Progress Bar', 'mobooking'); ?></option>
+                                            <option value="dots" <?php selected($settings->step_indicator_style, 'dots'); ?>><?php _e('Dots', 'mobooking'); ?></option>
+                                            <option value="numbers" <?php selected($settings->step_indicator_style, 'numbers'); ?>><?php _e('Numbers', 'mobooking'); ?></option>
+                                            <option value="arrows" <?php selected($settings->step_indicator_style, 'arrows'); ?>><?php _e('Arrows', 'mobooking'); ?></option>
+                                            <option value="none" <?php selected($settings->step_indicator_style, 'none'); ?>><?php _e('None', 'mobooking'); ?></option>
+                                        </select>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <label for="button-style" class="field-label"><?php _e('Button Style', 'mobooking'); ?></label>
+                                        <select id="button-style" name="button_style" class="form-control">
+                                            <option value="rounded" <?php selected($settings->button_style, 'rounded'); ?>><?php _e('Rounded', 'mobooking'); ?></option>
+                                            <option value="square" <?php selected($settings->button_style, 'square'); ?>><?php _e('Square', 'mobooking'); ?></option>
+                                            <option value="pill" <?php selected($settings->button_style, 'pill'); ?>><?php _e('Pill', 'mobooking'); ?></option>
+                                            <option value="outline" <?php selected($settings->button_style, 'outline'); ?>><?php _e('Outline', 'mobooking'); ?></option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Advanced Tab -->
+                <div class="tab-content" data-tab="advanced">
+                    <div class="content-grid">
+                        <!-- SEO Settings -->
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('SEO Optimization', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Optimize your booking form for search engines', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="form-group">
+                                    <label for="seo-title" class="field-label"><?php _e('Page Title', 'mobooking'); ?></label>
+                                    <input type="text" id="seo-title" name="seo_title" class="form-control"
+                                           value="<?php echo esc_attr($settings->seo_title); ?>"
+                                           placeholder="<?php _e('Book Our Services - Company Name', 'mobooking'); ?>">
+                                    <small class="field-note"><?php _e('Appears in browser title bar and search results', 'mobooking'); ?></small>
+                                </div>
+
+                                <div class="form-group">
+                                    <label for="seo-description" class="field-label"><?php _e('Meta Description', 'mobooking'); ?></label>
+                                    <textarea id="seo-description" name="seo_description" class="form-control" rows="3"
+                                              placeholder="<?php _e('Book our professional services easily online. Fast, reliable, and convenient scheduling...', 'mobooking'); ?>"><?php echo esc_textarea($settings->seo_description); ?></textarea>
+                                    <small class="field-note"><?php _e('Brief description for search engines (150-160 characters recommended)', 'mobooking'); ?></small>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Custom Code -->
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('Custom Code', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Add custom CSS and JavaScript to enhance your form', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="form-group">
+                                    <label for="custom-css" class="field-label"><?php _e('Custom CSS', 'mobooking'); ?></label>
+                                    <textarea id="custom-css" name="custom_css" class="form-control" rows="8"
+                                              style="font-family: monospace;"
+                                              placeholder="<?php _e('/* Custom CSS styles */\n.booking-form {\n    /* Your styles here */\n}', 'mobooking'); ?>"><?php echo esc_textarea($settings->custom_css); ?></textarea>
+                                    <small class="field-note"><?php _e('Custom CSS will override default styles.', 'mobooking'); ?></small>
+                                </div>
+
+                                <div class="form-group">
+                                    <label for="analytics-code" class="field-label"><?php _e('Analytics Code', 'mobooking'); ?></label>
+                                    <textarea id="analytics-code" name="analytics_code" class="form-control" rows="6"
+                                              style="font-family: monospace;"
+                                              placeholder="<?php _e('<!-- Google Analytics, Facebook Pixel, or other tracking codes -->', 'mobooking'); ?>"><?php echo esc_textarea($settings->analytics_code); ?></textarea>
+                                    <small class="field-note"><?php _e('Add Google Analytics, Facebook Pixel, or other tracking codes', 'mobooking'); ?></small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Share & Embed Tab -->
+                <div class="tab-content" data-tab="share">
+                    <div class="content-grid">
+                        <div class="settings-group">
+                            <div class="group-header">
+                                <h3 class="group-title"><?php _e('Share Your Form', 'mobooking'); ?></h3>
+                                <p class="group-description"><?php _e('Get your booking form URL and embed code', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="form-fields">
+                                <div class="form-group">
+                                    <label for="booking-url" class="field-label"><?php _e('Direct Link', 'mobooking'); ?></label>
+                                    <div style="display: flex; gap: 0.5rem;">
+                                        <input type="text" id="booking-url" class="form-control" readonly
+                                               value="<?php echo esc_url($booking_url); ?>" style="flex: 1;">
+                                        <button type="button" class="btn-secondary" onclick="copyToClipboard('#booking-url')">
+                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
+                                                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+                                            </svg>
+                                            <?php _e('Copy', 'mobooking'); ?>
+                                        </button>
+                                    </div>
+                                    <small class="field-note"><?php _e('Share this URL to let customers access your booking form directly', 'mobooking'); ?></small>
+                                </div>
+
+                                <div class="form-group">
+                                    <label for="embed-code" class="field-label"><?php _e('Embed Code', 'mobooking'); ?></label>
+                                    <textarea id="embed-code" class="form-control" rows="4" readonly
+                                              style="font-family: monospace;"><?php echo esc_textarea('<iframe src="' . esc_url($embed_url) . '" width="100%" height="800" frameborder="0"></iframe>'); ?></textarea>
+                                    <div style="display: flex; gap: 0.5rem; margin-top: 0.5rem;">
+                                        <button type="button" class="btn-secondary" onclick="copyToClipboard('#embed-code')">
+                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
+                                                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+                                            </svg>
+                                            <?php _e('Copy Code', 'mobooking'); ?>
+                                        </button>
+                                    </div>
+                                    <small class="field-note"><?php _e('Embed the booking form directly into your website', 'mobooking'); ?></small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Form Actions -->
+            <div class="form-actions">
+                <button type="button" id="reset-settings-btn" class="btn-secondary">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                        <path d="M3 3v5h5"/>
+                    </svg>
+                    <?php _e('Reset to Defaults', 'mobooking'); ?>
+                </button>
+                <button type="submit" id="save-settings-btn" class="btn-primary">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+                        <polyline points="17,21 17,13 7,13 7,21"/>
+                        <polyline points="7,3 7,8 15,8"/>
+                    </svg>
+                    <?php _e('Save Settings', 'mobooking'); ?>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+jQuery(document).ready(function($) {
+    console.log('MoBooking Dashboard JavaScript loaded');
+
+    // Enhanced booking form manager
+    const MoBookingDashboard = {
+
+        init: function() {
+            this.initTabs();
+            this.initColorPickers();
+            this.initFormSaving();
+            this.initResetSettings();
+            this.initPreview();
+            this.updateProgress();
+        },
+
+        // Tab functionality
+        initTabs: function() {
+            $('.mobooking-dashboard .tab-button').on('click', function() {
+                const tabId = $(this).data('tab');
+
+                // Update active tab button
+                $('.mobooking-dashboard .tab-button').removeClass('active');
+                $(this).addClass('active');
+
+                // Update active tab content
+                $('.mobooking-dashboard .tab-content').removeClass('active');
+                $(`.mobooking-dashboard .tab-content[data-tab="${tabId}"]`).addClass('active');
+            });
+        },
+
+        // Color picker functionality
+        initColorPickers: function() {
+            $('.mobooking-dashboard .color-picker').on('input change', function() {
+                const $colorPicker = $(this);
+                const $textInput = $colorPicker.siblings('.color-text');
+                $textInput.val($colorPicker.val());
+            });
+        },
+
+        // Form saving with enhanced validation
+        initFormSaving: function() {
+            $('#booking-form-settings').on('submit', function(e) {
+                e.preventDefault();
+
+                // Validate required fields
+                const formTitle = $('#form-title').val().trim();
+                if (!formTitle) {
+                    MoBookingDashboard.showNotification('<?php _e('Form title is required.', 'mobooking'); ?>', 'error');
+                    $('#form-title').focus();
+                    return;
+                }
+
+                // Show loading state
+                const $saveBtn = $('#save-settings-btn');
+                const originalHtml = $saveBtn.html();
+                $saveBtn.prop('disabled', true).html('<div class="spinner"></div> <?php _e('Saving...', 'mobooking'); ?>');
+
+                // Serialize form data
+                const formData = $(this).serialize() + '&action=mobooking_save_booking_form_settings';
+
+                $.ajax({
+                    url: '<?php echo admin_url('admin-ajax.php'); ?>',
+                    type: 'POST',
+                    data: formData,
+                    success: function(response) {
+                        if (response.success) {
+                            MoBookingDashboard.showNotification('<?php _e('Settings saved successfully!', 'mobooking'); ?>', 'success');
+                            MoBookingDashboard.updateProgress();
+
+                            // Update URLs if they changed
+                            if (response.data && response.data.booking_url) {
+                                $('#booking-url').val(response.data.booking_url);
+                            }
+                        } else {
+                            MoBookingDashboard.showNotification(
+                                response.data || '<?php _e('Failed to save settings.', 'mobooking'); ?>',
+                                'error'
+                            );
+                        }
+                    },
+                    error: function(xhr, status, error) {
+                        console.error('AJAX Error:', {xhr, status, error});
+                        let errorMessage = '<?php _e('An error occurred while saving settings.', 'mobooking'); ?>';
+
+                        if (xhr.status === 0) {
+                            errorMessage = '<?php _e('Network error. Please check your connection.', 'mobooking'); ?>';
+                        } else if (xhr.status === 403) {
+                            errorMessage = '<?php _e('Permission denied. Please refresh the page and try again.', 'mobooking'); ?>';
+                        } else if (xhr.status === 500) {
+                            errorMessage = '<?php _e('Server error. Please check the error logs.', 'mobooking'); ?>';
+                        }
+
+                        MoBookingDashboard.showNotification(errorMessage, 'error');
+                    },
+                    complete: function() {
+                        // Restore button state
+                        $saveBtn.prop('disabled', false).html(originalHtml);
+                    }
+                });
+            });
+        },
+
+        // Reset settings
+        initResetSettings: function() {
+            $('#reset-settings-btn').on('click', function() {
+                if (confirm('<?php _e('Are you sure you want to reset all settings to defaults? This action cannot be undone.', 'mobooking'); ?>')) {
+                    const $resetBtn = $(this);
+                    const originalHtml = $resetBtn.html();
+                    $resetBtn.prop('disabled', true).html('<div class="spinner"></div> <?php _e('Resetting...', 'mobooking'); ?>');
+
+                    $.ajax({
+                        url: '<?php echo admin_url('admin-ajax.php'); ?>',
+                        type: 'POST',
+                        data: {
+                            action: 'mobooking_reset_booking_form_settings',
+                            nonce: $('input[name="nonce"]').val()
+                        },
+                        success: function(response) {
+                            if (response.success) {
+                                MoBookingDashboard.showNotification('<?php _e('Settings reset successfully!', 'mobooking'); ?>', 'success');
+                                setTimeout(() => location.reload(), 1000);
+                            } else {
+                                MoBookingDashboard.showNotification(
+                                    response.data || '<?php _e('Failed to reset settings.', 'mobooking'); ?>',
+                                    'error'
+                                );
+                            }
+                        },
+                        error: function() {
+                            MoBookingDashboard.showNotification('<?php _e('An error occurred while resetting settings.', 'mobooking'); ?>', 'error');
+                        },
+                        complete: function() {
+                            $resetBtn.prop('disabled', false).html(originalHtml);
+                        }
+                    });
+                }
+            });
+        },
+
+        // Preview functionality
+        initPreview: function() {
+            $('#preview-btn').on('click', function() {
+                const bookingUrl = $('#booking-url').val();
+                if (bookingUrl) {
+                    window.open(bookingUrl, '_blank');
+                } else {
+                    MoBookingDashboard.showNotification('<?php _e('Booking URL not available. Please save settings first.', 'mobooking'); ?>', 'warning');
+                }
+            });
+        },
+
+        // Update setup progress
+        updateProgress: function() {
+            // This could be enhanced to dynamically check completion status
+            const servicesComplete = <?php echo $setup_steps['services'] ? 'true' : 'false'; ?>;
+            const areasComplete = <?php echo $setup_steps['areas'] ? 'true' : 'false'; ?>;
+            const designComplete = $('#form-title').val().trim() !== '' && $('#primary-color').val() !== '';
+            const seoComplete = $('#seo-title').val().trim() !== '' && $('#seo-description').val().trim() !== '';
+
+            const completedSteps = [servicesComplete, areasComplete, designComplete, seoComplete].filter(Boolean).length;
+            const totalSteps = 4;
+            const percentage = Math.round((completedSteps / totalSteps) * 100);
+
+            $('.progress-percentage').text(percentage + '%');
+            $('.progress-bar').css('width', percentage + '%');
+        },
+
+        // Notification system
+        showNotification: function(message, type = 'info') {
+            // Remove existing notifications
+            $('.mobooking-dashboard .notification').remove();
+
+            const notification = $(`
+                <div class="notification ${type}">
+                    <span>${message}</span>
+                    <button type="button" class="notification-close">&times;</button>
+                </div>
+            `);
+
+            $('body').append(notification);
+
+            // Auto-hide after 5 seconds
+            setTimeout(() => {
+                notification.fadeOut();
+            }, 5000);
+
+            // Close button handler
+            notification.find('.notification-close').on('click', function() {
+                notification.fadeOut();
+            });
+        }
+    };
+
+    // Copy to clipboard function
+    window.copyToClipboard = function(selector) {
+        const $element = $(selector);
+        if ($element.length) {
+            $element.select();
+            document.execCommand('copy');
+
+            // Show success feedback
+            const $button = $element.siblings('button').last();
+            const originalHtml = $button.html();
+            $button.html('<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20,6 9,17 4,12"/></svg> <?php _e('Copied!', 'mobooking'); ?>');
+
+            setTimeout(() => {
+                $button.html(originalHtml);
+            }, 2000);
+        }
+    };
+
+    // Initialize the dashboard
+    MoBookingDashboard.init();
+
+    // Make globally available for debugging
+    window.MoBookingDashboard = MoBookingDashboard;
+});
+</script>
+
+<?php
+// Enhanced AJAX handler for saving booking form settings
+add_action('wp_ajax_mobooking_save_booking_form_settings', function() {
+    try {
+        // Check nonce
+        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking-booking-form-nonce')) {
+            wp_send_json_error(__('Security verification failed.', 'mobooking'));
+        }
+
+        // Check permissions
+        if (!current_user_can('mobooking_business_owner') && !current_user_can('administrator')) {
+            wp_send_json_error(__('You do not have permission to do this.', 'mobooking'));
+        }
+
+        $user_id = get_current_user_id();
+
+        // Map form fields correctly
+        $settings_data = array(
+            // Basic Information
+            'form_title' => sanitize_text_field($_POST['form_title'] ?? ''),
+            'form_description' => sanitize_textarea_field($_POST['form_description'] ?? ''),
+            'is_active' => isset($_POST['is_active']) ? absint($_POST['is_active']) : 0,
+            'language' => sanitize_text_field($_POST['language'] ?? 'en'),
+
+            // Form Features
+            'show_form_header' => isset($_POST['show_form_header']) ? 1 : 0,
+            'show_service_descriptions' => isset($_POST['show_service_descriptions']) ? 1 : 0,
+            'show_price_breakdown' => isset($_POST['show_price_breakdown']) ? 1 : 0,
+            'enable_zip_validation' => isset($_POST['enable_zip_validation']) ? 1 : 0,
+            'show_form_footer' => isset($_POST['show_form_footer']) ? 1 : 0,
+
+            // Design & Branding
+            'primary_color' => sanitize_hex_color($_POST['primary_color'] ?? '#3b82f6'),
+            'secondary_color' => sanitize_hex_color($_POST['secondary_color'] ?? '#1e40af'),
+            'background_color' => sanitize_hex_color($_POST['background_color'] ?? '#ffffff'),
+            'text_color' => sanitize_hex_color($_POST['text_color'] ?? '#1f2937'),
+
+            // Layout & Style
+            'form_layout' => sanitize_text_field($_POST['form_layout'] ?? 'modern'),
+            'form_width' => sanitize_text_field($_POST['form_width'] ?? 'standard'),
+            'step_indicator_style' => sanitize_text_field($_POST['step_indicator_style'] ?? 'progress'),
+            'button_style' => sanitize_text_field($_POST['button_style'] ?? 'rounded'),
+
+            // SEO Optimization
+            'seo_title' => sanitize_text_field($_POST['seo_title'] ?? ''),
+            'seo_description' => sanitize_textarea_field($_POST['seo_description'] ?? ''),
+
+            // Custom Code
+            'analytics_code' => wp_kses_post($_POST['analytics_code'] ?? ''),
+            'custom_css' => wp_strip_all_tags($_POST['custom_css'] ?? '')
+        );
+
+        // Save settings using BookingForm Manager
+        $booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
+        $result = $booking_form_manager->save_settings($user_id, $settings_data);
+
+        if ($result) {
+            $response_data = array(
+                'message' => __('Settings saved successfully!', 'mobooking'),
+                'booking_url' => $booking_form_manager->get_booking_form_url($user_id),
+                'embed_url' => $booking_form_manager->get_embed_url($user_id)
+            );
+
+            wp_send_json_success($response_data);
+        } else {
+            wp_send_json_error(__('Failed to save settings.', 'mobooking'));
+        }
+
+    } catch (Exception $e) {
+        error_log('MoBooking - Exception in save booking form settings: ' . $e->getMessage());
+        wp_send_json_error(__('An error occurred while saving settings.', 'mobooking'));
+    }
+});
+
+// AJAX handler for resetting booking form settings
+add_action('wp_ajax_mobooking_reset_booking_form_settings', function() {
+    try {
+        // Check nonce
+        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mobooking-booking-form-nonce')) {
+            wp_send_json_error(__('Security verification failed.', 'mobooking'));
+        }
+
+        // Check permissions
+        if (!current_user_can('mobooking_business_owner') && !current_user_can('administrator')) {
+            wp_send_json_error(__('You do not have permission to do this.', 'mobooking'));
+        }
+
+        $user_id = get_current_user_id();
+
+        // Reset to default settings
+        $default_settings = array(
+            'form_title' => __('Book Our Services', 'mobooking'),
+            'form_description' => __('Select your service and schedule an appointment', 'mobooking'),
+            'is_active' => 1,
+            'language' => 'en',
+            'show_form_header' => 1,
+            'show_service_descriptions' => 1,
+            'show_price_breakdown' => 1,
+            'enable_zip_validation' => 0,
+            'show_form_footer' => 1,
+            'primary_color' => '#3b82f6',
+            'secondary_color' => '#1e40af',
+            'background_color' => '#ffffff',
+            'text_color' => '#1f2937',
+            'form_layout' => 'modern',
+            'form_width' => 'standard',
+            'step_indicator_style' => 'progress',
+            'button_style' => 'rounded',
+            'seo_title' => '',
+            'seo_description' => '',
+            'analytics_code' => '',
+            'custom_css' => ''
+        );
+
+        $booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
+        $result = $booking_form_manager->save_settings($user_id, $default_settings);
+
+        if ($result) {
+            wp_send_json_success(array(
+                'message' => __('Settings reset successfully!', 'mobooking')
+            ));
+        } else {
+            wp_send_json_error(__('Failed to reset settings.', 'mobooking'));
+        }
+
+    } catch (Exception $e) {
+        error_log('MoBooking - Exception in reset booking form settings: ' . $e->getMessage());
+        wp_send_json_error(__('An error occurred while resetting settings.', 'mobooking'));
+    }
+});
+?>

--- a/page-bookings.php
+++ b/page-bookings.php
@@ -1,0 +1,2008 @@
+<?php
+// dashboard/sections/bookings.php - ENHANCED Responsive Bookings Management Section
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Initialize bookings manager
+$bookings_manager = new \MoBooking\Bookings\Manager();
+
+// Get current view (list or individual booking)
+$current_view = isset($_GET['view']) ? sanitize_text_field($_GET['view']) : 'list';
+$booking_id = isset($_GET['booking_id']) ? absint($_GET['booking_id']) : 0;
+
+// Handle individual booking view
+if ($current_view === 'booking' && $booking_id) {
+    include(MOBOOKING_PATH . '/page-single-booking.php');
+    return;
+}
+
+// Get filter parameters
+$status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
+$date_filter = isset($_GET['date_range']) ? sanitize_text_field($_GET['date_range']) : '';
+$search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
+$view_mode = isset($_GET['view_mode']) ? sanitize_text_field($_GET['view_mode']) : 'cards';
+
+// Pagination
+$page = isset($_GET['paged']) ? absint($_GET['paged']) : 1;
+$per_page = ($view_mode === 'compact') ? 50 : 20;
+$offset = ($page - 1) * $per_page;
+
+// Build query arguments
+$args = array(
+    'limit' => $per_page,
+    'offset' => $offset,
+    'orderby' => 'created_at',
+    'order' => 'DESC'
+);
+
+if ($status_filter) {
+    $args['status'] = $status_filter;
+}
+
+if ($date_filter) {
+    switch($date_filter) {
+        case 'today':
+            $args['date_from'] = date('Y-m-d');
+            $args['date_to'] = date('Y-m-d');
+            break;
+        case 'this_week':
+            $args['date_from'] = date('Y-m-d', strtotime('monday this week'));
+            $args['date_to'] = date('Y-m-d', strtotime('sunday this week'));
+            break;
+        case 'this_month':
+            $args['date_from'] = date('Y-m-01');
+            $args['date_to'] = date('Y-m-t');
+            break;
+        case 'last_30_days':
+            $args['date_from'] = date('Y-m-d', strtotime('-30 days'));
+            $args['date_to'] = date('Y-m-d');
+            break;
+    }
+}
+
+// Get bookings and statistics
+$bookings = $bookings_manager->get_user_bookings($user_id, $args);
+$total_bookings = $bookings_manager->count_user_bookings($user_id, $status_filter);
+
+// Get statistics
+$stats = array(
+    'total' => $bookings_manager->count_user_bookings($user_id),
+    'pending' => $bookings_manager->count_user_bookings($user_id, 'pending'),
+    'confirmed' => $bookings_manager->count_user_bookings($user_id, 'confirmed'),
+    'completed' => $bookings_manager->count_user_bookings($user_id, 'completed'),
+    'cancelled' => $bookings_manager->count_user_bookings($user_id, 'cancelled'),
+    'total_revenue' => $bookings_manager->calculate_user_revenue($user_id),
+    'this_month_revenue' => $bookings_manager->calculate_user_revenue($user_id, 'this_month'),
+    'today_revenue' => $bookings_manager->calculate_user_revenue($user_id, 'today')
+);
+
+// Calculate pagination
+$total_pages = ceil($total_bookings / $per_page);
+
+// Get upcoming bookings (next 7 days)
+$upcoming_args = array(
+    'limit' => 5,
+    'date_from' => date('Y-m-d'),
+    'date_to' => date('Y-m-d', strtotime('+7 days')),
+    'status' => 'confirmed'
+);
+$upcoming_bookings = $bookings_manager->get_user_bookings($user_id, $upcoming_args);
+?>
+
+<div class="bookings-page">
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="header-content">
+            <div class="header-info">
+                <h1 class="page-title">
+                    <svg class="title-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M16 2V6M8 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z"/>
+                    </svg>
+                    Bookings
+                    <?php if ($total_bookings > 0) : ?>
+                        <span class="bookings-count"><?php echo number_format($total_bookings); ?></span>
+                    <?php endif; ?>
+                </h1>
+                <p class="page-subtitle">Manage and track your service bookings</p>
+            </div>
+
+            <div class="header-actions">
+                <button type="button" class="btn-secondary" id="bulk-actions-btn" style="display: none;">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M9 12l2 2 4-4M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9c1.94 0 3.73.62 5.18 1.67"/>
+                    </svg>
+                    <span class="selected-count">0</span> Selected
+                </button>
+
+                <div class="header-action-group">
+                    <button type="button" class="btn-secondary" id="export-bookings-btn">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-15"/>
+                            <path d="M7 10l5 5 5-5"/>
+                            <path d="M12 15V3"/>
+                        </svg>
+                        Export
+                    </button>
+
+                    <button type="button" class="btn-primary" id="new-booking-btn">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 5v14M5 12h14"/>
+                        </svg>
+                        New Booking
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Analytics Section -->
+    <div class="analytics-section">
+        <div class="analytics-grid">
+            <div class="metric-card metric-total">
+                <div class="metric-header">
+                    <div class="metric-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16 2V6M8 2V6M3 10H21"/>
+                            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                        </svg>
+                    </div>
+                    <span class="metric-trend positive">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M7 14l5-5 5 5"/>
+                        </svg>
+                        12%
+                    </span>
+                </div>
+                <div class="metric-content">
+                    <div class="metric-value"><?php echo number_format($stats['total']); ?></div>
+                    <div class="metric-label">Total Bookings</div>
+                    <div class="metric-subtitle">All time</div>
+                </div>
+            </div>
+
+            <div class="metric-card metric-pending<?php echo $stats['pending'] > 0 ? ' metric-alert' : ''; ?>">
+                <div class="metric-header">
+                    <div class="metric-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <polyline points="12,6 12,12 16,14"/>
+                        </svg>
+                    </div>
+                    <?php if ($stats['pending'] > 0) : ?>
+                        <span class="metric-alert-badge">
+                            <div class="alert-pulse"></div>
+                            Action needed
+                        </span>
+                    <?php endif; ?>
+                </div>
+                <div class="metric-content">
+                    <div class="metric-value"><?php echo number_format($stats['pending']); ?></div>
+                    <div class="metric-label">Pending Review</div>
+                    <div class="metric-subtitle">Awaiting confirmation</div>
+                </div>
+            </div>
+
+            <div class="metric-card metric-confirmed">
+                <div class="metric-header">
+                    <div class="metric-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+                            <polyline points="22,4 12,14.01 9,11.01"/>
+                        </svg>
+                    </div>
+                    <span class="metric-trend positive">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M7 14l5-5 5 5"/>
+                        </svg>
+                        5%
+                    </span>
+                </div>
+                <div class="metric-content">
+                    <div class="metric-value"><?php echo number_format($stats['confirmed']); ?></div>
+                    <div class="metric-label">Confirmed</div>
+                    <div class="metric-subtitle">Ready to serve</div>
+                </div>
+            </div>
+
+            <div class="metric-card metric-revenue">
+                <div class="metric-header">
+                    <div class="metric-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="12" y1="1" x2="12" y2="23"/>
+                            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+                        </svg>
+                    </div>
+                    <span class="metric-trend positive">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M7 14l5-5 5 5"/>
+                        </svg>
+                        23%
+                    </span>
+                </div>
+                <div class="metric-content">
+                    <div class="metric-value"><?php echo function_exists('wc_price') ? wc_price($stats['total_revenue']) : '$' . number_format($stats['total_revenue'], 2); ?></div>
+                    <div class="metric-label">Total Revenue</div>
+                    <div class="metric-subtitle">This month: <?php echo function_exists('wc_price') ? wc_price($stats['this_month_revenue']) : '$' . number_format($stats['this_month_revenue'], 2); ?></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Quick Insights -->
+        <?php if (!empty($upcoming_bookings)) : ?>
+            <div class="quick-insights">
+                <div class="insight-card">
+                    <div class="insight-header">
+                        <h3>
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="10"/>
+                                <polyline points="12,6 12,12 16,14"/>
+                            </svg>
+                            Upcoming This Week
+                        </h3>
+                        <span class="insight-count"><?php echo count($upcoming_bookings); ?></span>
+                    </div>
+                    <div class="upcoming-list">
+                        <?php foreach (array_slice($upcoming_bookings, 0, 3) as $upcoming) :
+                            $upcoming_date = new DateTime($upcoming->service_date);
+                        ?>
+                            <div class="upcoming-item">
+                                <div class="upcoming-date">
+                                    <div class="date-day"><?php echo $upcoming_date->format('d'); ?></div>
+                                    <div class="date-month"><?php echo $upcoming_date->format('M'); ?></div>
+                                </div>
+                                <div class="upcoming-details">
+                                    <div class="upcoming-customer"><?php echo esc_html($upcoming->customer_name); ?></div>
+                                    <div class="upcoming-time"><?php echo $upcoming_date->format('g:i A'); ?></div>
+                                </div>
+                                <div class="upcoming-actions">
+                                    <a href="<?php echo esc_url(add_query_arg(array('view' => 'booking', 'booking_id' => $upcoming->id))); ?>"
+                                       class="upcoming-view-btn">
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M9 18l6-6-6-6"/>
+                                        </svg>
+                                    </a>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <!-- Controls Section -->
+    <div class="controls-section">
+        <div class="controls-grid">
+            <!-- Status Filter -->
+                <div class="filter-group">
+                    <label for="status-filter" class="filter-label">Status</label>
+                <select id="status-filter" class="filter-select">
+                    <option value="">All Statuses</option>
+                    <option value="pending">Pending</option>
+                    <option value="confirmed">Confirmed</option>
+                    <option value="completed">Completed</option>
+                    <option value="cancelled">Cancelled</option>
+                    </select>
+                </div>
+
+            <!-- Date Range Filter -->
+                <div class="filter-group">
+                    <label for="date-filter" class="filter-label">Date Range</label>
+                <select id="date-filter" class="filter-select">
+                    <option value="">All Time</option>
+                    <option value="today">Today</option>
+                    <option value="this_week">This Week</option>
+                    <option value="this_month">This Month</option>
+                    </select>
+                </div>
+
+            <!-- Search Input -->
+            <div class="filter-group search-group">
+                <label for="search-input" class="filter-label">Search</label>
+                <div class="search-input-wrapper">
+                    <input type="text" id="search-input" class="search-input" placeholder="Search bookings...">
+                    <button class="clear-search-btn" aria-label="Clear search">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M18 6L6 18M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+            <!-- Reset Button -->
+            <div class="filter-group">
+                <button id="reset-filters" class="btn-secondary">Reset Filters</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bookings Content -->
+    <div class="bookings-content">
+        <?php if (empty($bookings)) : ?>
+            <!-- Empty State -->
+            <div class="empty-state">
+                <div class="empty-state-icon">
+                    <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path d="M16 2V6M8 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z"/>
+                    </svg>
+                </div>
+                <div class="empty-state-content">
+                    <?php if ($search_query || $status_filter || $date_filter) : ?>
+                        <h3><?php _e('No Bookings Found', 'mobooking'); ?></h3>
+                        <p><?php _e('No bookings match your current filters. Try adjusting your search criteria.', 'mobooking'); ?></p>
+                        <button type="button" class="btn-primary" id="clear-all-filters">
+                            <?php _e('Clear All Filters', 'mobooking'); ?>
+                        </button>
+                    <?php else : ?>
+                        <h3><?php _e('No Bookings Yet', 'mobooking'); ?></h3>
+                        <p><?php _e('Your bookings will appear here once customers start booking your services.', 'mobooking'); ?></p>
+                        <div class="empty-actions">
+                            <a href="<?php echo esc_url(home_url('/dashboard/booking-form/')); ?>" class="btn-primary">
+                                <?php _e('Setup Booking Form', 'mobooking'); ?>
+                            </a>
+                            <a href="<?php echo esc_url(home_url('/dashboard/services/')); ?>" class="btn-secondary">
+                                <?php _e('Manage Services', 'mobooking'); ?>
+                            </a>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php else : ?>
+            <!-- Bookings List -->
+            <div class="bookings-container">
+                <div class="bookings-list-container">
+                    <!-- List Header -->
+                    <div class="bookings-list-header">
+                        <div class="header-cell">Booking ID</div>
+                        <div class="header-cell">Client</div>
+                        <div class="header-cell">Service</div>
+                        <div class="header-cell">Date</div>
+                        <div class="header-cell">Status</div>
+                        <div class="header-cell">Actions</div>
+                    </div>
+
+                    <!-- Bookings List -->
+                    <div class="bookings-list">
+                    <?php
+                    $services_manager = new \MoBooking\Services\ServicesManager();
+                    foreach ($bookings as $booking) :
+                            $services_data = is_array($booking->services) ? $booking->services : json_decode($booking->services, true);
+                            $service_name = '';
+
+                            if (is_array($services_data) && !empty($services_data)) {
+                                $service = $services_manager->get_service($services_data[0]);
+                                if ($service) {
+                                    $service_name = $service->name;
+                            }
+                        }
+
+                        $service_date = new DateTime($booking->service_date);
+                            $status_class = 'status-' . $booking->status;
+                        ?>
+                        <div class="booking-row" data-booking-id="<?php echo esc_attr($booking->id); ?>">
+                            <div class="booking-cell">#<?php echo esc_html($booking->id); ?></div>
+                            <div class="booking-cell">
+                                <div class="client-info">
+                                    <div class="client-name"><?php echo esc_html($booking->customer_name); ?></div>
+                                    <div class="client-email"><?php echo esc_html($booking->customer_email); ?></div>
+                                </div>
+                                </div>
+                            <div class="booking-cell"><?php echo esc_html($service_name); ?></div>
+                            <div class="booking-cell"><?php echo esc_html($service_date->format('M d, Y')); ?></div>
+                            <div class="booking-cell">
+                                <span class="status-badge <?php echo esc_attr($status_class); ?>">
+                                    <?php echo esc_html(ucfirst($booking->status)); ?>
+                                    </span>
+                                        </div>
+                            <div class="booking-cell">
+                                <a href="<?php echo esc_url(add_query_arg(['view' => 'booking', 'booking_id' => $booking->id])); ?>" class="btn-view-details">
+                                    View Details
+                                        </a>
+                                    </div>
+                                        </div>
+                                                <?php endforeach; ?>
+                                        </div>
+                </div>
+            </div>
+
+            <!-- Pagination -->
+            <?php if ($total_pages > 1) : ?>
+                <div class="pagination-container">
+                    <div class="pagination-info">
+                        <?php
+                        $start = ($page - 1) * $per_page + 1;
+                        $end = min($page * $per_page, $total_bookings);
+                        printf(__('Showing %d-%d of %d bookings', 'mobooking'), $start, $end, $total_bookings);
+                        ?>
+                    </div>
+
+                    <div class="pagination-controls">
+                        <?php if ($page > 1) : ?>
+                            <a href="<?php echo esc_url(add_query_arg('paged', $page - 1)); ?>" class="pagination-btn pagination-prev">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M15 18l-6-6 6-6"/>
+                                </svg>
+                                Previous
+                            </a>
+                        <?php endif; ?>
+
+                        <div class="pagination-numbers">
+                            <?php
+                            $start_page = max(1, $page - 2);
+                            $end_page = min($total_pages, $page + 2);
+
+                            if ($start_page > 1) {
+                                echo '<a href="' . esc_url(add_query_arg('paged', 1)) . '" class="pagination-number">1</a>';
+                                if ($start_page > 2) {
+                                    echo '<span class="pagination-ellipsis">...</span>';
+                                }
+                            }
+
+                            for ($i = $start_page; $i <= $end_page; $i++) {
+                                if ($i == $page) {
+                                    echo '<span class="pagination-number current">' . $i . '</span>';
+                                } else {
+                                    echo '<a href="' . esc_url(add_query_arg('paged', $i)) . '" class="pagination-number">' . $i . '</a>';
+                                }
+                            }
+
+                            if ($end_page < $total_pages) {
+                                if ($end_page < $total_pages - 1) {
+                                    echo '<span class="pagination-ellipsis">...</span>';
+                                }
+                                echo '<a href="' . esc_url(add_query_arg('paged', $total_pages)) . '" class="pagination-number">' . $total_pages . '</a>';
+                            }
+                            ?>
+                        </div>
+
+                        <?php if ($page < $total_pages) : ?>
+                            <a href="<?php echo esc_url(add_query_arg('paged', $page + 1)); ?>" class="pagination-btn pagination-next">
+                                Next
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M9 18l6-6-6-6"/>
+                                </svg>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            <?php endif; ?>
+        <?php endif; ?>
+    </div>
+</div>
+
+<!-- Bulk Actions Modal -->
+<div id="bulk-actions-modal" class="mobooking-modal" style="display: none;">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3><?php _e('Bulk Actions', 'mobooking'); ?></h3>
+            <button type="button" class="modal-close">&times;</button>
+        </div>
+        <div class="modal-body">
+            <p><span class="bulk-count">0</span> <?php _e('bookings selected. Choose an action:', 'mobooking'); ?></p>
+            <div class="bulk-actions-grid">
+                <button type="button" class="bulk-action-btn confirm-bulk" data-action="confirmed">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+                        <polyline points="22,4 12,14.01 9,11.01"/>
+                    </svg>
+                    <span><?php _e('Confirm All', 'mobooking'); ?></span>
+                </button>
+
+                <button type="button" class="bulk-action-btn complete-bulk" data-action="completed">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                    </svg>
+                    <span><?php _e('Mark Completed', 'mobooking'); ?></span>
+                </button>
+
+                <button type="button" class="bulk-action-btn cancel-bulk" data-action="cancelled">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="12" cy="12" r="10"/>
+                        <path d="M15 9l-6 6M9 9l6 6"/>
+                    </svg>
+                    <span><?php _e('Cancel All', 'mobooking'); ?></span>
+                </button>
+
+                <button type="button" class="bulk-action-btn export-bulk" data-action="export">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-15"/>
+                        <path d="M7 10l5 5 5-5"/>
+                        <path d="M12 15V3"/>
+                    </svg>
+                    <span><?php _e('Export Selected', 'mobooking'); ?></span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Enhanced JavaScript -->
+<script>
+jQuery(document).ready(function($) {
+    // Initialize filters
+    const BookingsManager = {
+        init: function() {
+            this.bindEvents();
+            this.initializeFilters();
+        },
+
+        bindEvents: function() {
+            // Status filter
+            $('#status-filter').on('change', () => this.filterBookings());
+
+            // Date filter
+            $('#date-filter').on('change', () => this.filterBookings());
+
+            // Search input
+            $('#search-input').on('input', () => this.filterBookings());
+
+            // Clear search
+            $('.clear-search-btn').on('click', () => {
+                $('#search-input').val('');
+                this.filterBookings();
+            });
+
+            // Reset filters
+            $('#reset-filters').on('click', () => {
+                $('#status-filter').val('');
+                $('#date-filter').val('');
+                $('#search-input').val('');
+                this.filterBookings();
+                // Remove parameters from URL
+                window.history.replaceState({}, '', window.location.pathname);
+            });
+        },
+
+        initializeFilters: function() {
+            // Set initial filter values from URL parameters
+            const urlParams = new URLSearchParams(window.location.search);
+            $('#status-filter').val(urlParams.get('status') || '');
+            $('#date-filter').val(urlParams.get('date_range') || '');
+            $('#search-input').val(urlParams.get('search') || '');
+
+            // Apply initial filters
+            this.filterBookings();
+        },
+
+        filterBookings: function() {
+            const status = $('#status-filter').val();
+            const dateRange = $('#date-filter').val();
+            const searchQuery = ($('#search-input').val() || '').toLowerCase();
+
+            let visibleCount = 0;
+
+            $('.booking-row').each(function() {
+                const $row = $(this);
+                const safeText = (selector) => ($row.find(selector).text() || '').toLowerCase();
+                const bookingId = safeText('.booking-cell:first');
+                const clientName = safeText('.client-name');
+                const clientEmail = safeText('.client-email');
+                const serviceName = safeText('.booking-cell:nth-child(3)');
+                const rowStatus = safeText('.status-badge');
+
+                let show = true;
+
+                // Status filter
+                if ($('#status-filter').val() && rowStatus !== $('#status-filter').val().toLowerCase()) {
+                    show = false;
+                }
+
+                // Search filter
+                if (searchQuery) {
+                    const matchesSearch =
+                        bookingId.includes(searchQuery) ||
+                        clientName.includes(searchQuery) ||
+                        clientEmail.includes(searchQuery) ||
+                        serviceName.includes(searchQuery);
+
+                    if (!matchesSearch) {
+                        show = false;
+                    }
+                }
+
+                // Date filter
+                if (dateRange) {
+                    const bookingDate = new Date($row.find('.booking-cell:nth-child(4)').text());
+                    const today = new Date();
+                    const startOfWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - today.getDay());
+                    const endOfWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - today.getDay() + 6);
+                    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+                    const endOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+                    switch(dateRange) {
+                        case 'today':
+                            if (bookingDate.toDateString() !== (new Date()).toDateString()) {
+                                show = false;
+                            }
+                            break;
+                        case 'this_week':
+                            if (bookingDate < startOfWeek || bookingDate > endOfWeek) {
+                                show = false;
+                            }
+                            break;
+                        case 'this_month':
+                            if (bookingDate < startOfMonth || bookingDate > endOfMonth) {
+                                show = false;
+                            }
+                    break;
+            }
+                }
+
+                $row.toggle(show);
+                if (show) visibleCount++;
+            });
+
+            // Show/hide no-result-found empty state
+            if (visibleCount === 0) {
+                $('.empty-state-content').show();
+                } else {
+                $('.empty-state-content').hide();
+            }
+
+            // Update URL with current filters
+            const params = new URLSearchParams(window.location.search);
+            if (status) params.set('status', status);
+            if (dateRange) params.set('date_range', dateRange);
+            if (searchQuery) params.set('search', searchQuery);
+
+            const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+            window.history.replaceState({}, '', newUrl);
+        }
+    };
+
+    BookingsManager.init();
+});
+
+</script>
+
+
+<style>
+/* Enhanced Responsive Bookings Section CSS */
+
+/* ==================================================
+   LAYOUT & CONTAINERS
+   ================================================== */
+
+.bookings-page {
+    animation: fadeInUp 0.6s ease-out;
+}
+
+/* Page Header */
+.page-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.header-content {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+}
+
+.header-info {
+    flex: 1;
+}
+
+.page-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 0.5rem 0;
+    font-size: 2rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+    line-height: 1.2;
+}
+
+.title-icon {
+    width: 2rem;
+    height: 2rem;
+    color: hsl(var(--primary));
+    flex-shrink: 0;
+}
+
+.bookings-count {
+    background: hsl(var(--primary) / 0.1);
+    color: hsl(var(--primary));
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-left: 0.5rem;
+}
+
+.page-subtitle {
+    margin: 0;
+    font-size: 1rem;
+    color: hsl(var(--muted-foreground));
+    line-height: 1.5;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-shrink: 0;
+}
+
+.header-action-group {
+    display: flex;
+    gap: 0.75rem;
+}
+
+/* ==================================================
+   ANALYTICS SECTION
+   ================================================== */
+
+.analytics-section {
+    margin-bottom: 2rem;
+}
+
+.analytics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.metric-card {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    padding: 1.5rem;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+}
+
+.metric-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, hsl(var(--primary)), transparent);
+    transform: translateX(-100%);
+    transition: transform 0.6s ease;
+}
+
+.metric-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 25px hsl(var(--primary) / 0.1);
+}
+
+.metric-card:hover::before {
+    transform: translateX(100%);
+}
+
+.metric-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.metric-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: hsl(var(--primary) / 0.1);
+    color: hsl(var(--primary));
+}
+
+.metric-total .metric-icon {
+    background: hsl(var(--info) / 0.1);
+    color: hsl(var(--info));
+}
+
+.metric-pending .metric-icon {
+    background: hsl(var(--warning) / 0.1);
+    color: hsl(var(--warning));
+}
+
+.metric-confirmed .metric-icon {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+}
+
+.metric-revenue .metric-icon {
+    background: hsl(var(--primary) / 0.1);
+    color: hsl(var(--primary));
+}
+
+.metric-trend {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border-radius: 20px;
+}
+
+.metric-trend.positive {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+}
+
+.metric-trend.negative {
+    background: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+}
+
+.metric-alert-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: hsl(var(--warning));
+    background: hsl(var(--warning) / 0.1);
+    padding: 0.25rem 0.5rem;
+    border-radius: 20px;
+    position: relative;
+}
+
+.alert-pulse {
+    width: 0.5rem;
+    height: 0.5rem;
+    background: hsl(var(--warning));
+    border-radius: 50%;
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.7;
+        transform: scale(1.2);
+    }
+}
+
+.metric-content {
+    text-align: left;
+}
+
+.metric-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+    line-height: 1;
+    margin-bottom: 0.5rem;
+}
+
+.metric-label {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+}
+
+.metric-subtitle {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+}
+
+/* Quick Insights */
+.quick-insights {
+    margin-top: 1.5rem;
+}
+
+.insight-card {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    padding: 1.5rem;
+}
+
+.insight-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.insight-header h3 {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.insight-count {
+    background: hsl(var(--primary) / 0.1);
+    color: hsl(var(--primary));
+    padding: 0.25rem 0.75rem;
+    border-radius: 20px;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.upcoming-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.upcoming-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.upcoming-item:hover {
+    background: hsl(var(--muted) / 0.3);
+    border-color: hsl(var(--primary) / 0.3);
+}
+
+.upcoming-date {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    background: hsl(var(--primary) / 0.1);
+    border-radius: 8px;
+    padding: 0.5rem;
+    min-width: 3rem;
+}
+
+.date-day {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: hsl(var(--primary));
+    line-height: 1;
+}
+
+.date-month {
+    font-size: 0.75rem;
+    color: hsl(var(--primary));
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.upcoming-details {
+    flex: 1;
+}
+
+.upcoming-customer {
+    font-weight: 500;
+    color: hsl(var(--foreground));
+    margin-bottom: 0.125rem;
+}
+
+.upcoming-time {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.upcoming-view-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 6px;
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    color: hsl(var(--muted-foreground));
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.upcoming-view-btn:hover {
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
+    color: white;
+}
+
+/* ==================================================
+   CONTROLS SECTION
+   ================================================== */
+
+.controls-section {
+    margin-bottom: 2rem;
+}
+
+.controls-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.filter-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: hsl(var(--foreground));
+}
+
+.filter-select {
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+}
+
+.search-group {
+    grid-column: span 2;
+}
+
+.search-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.search-input {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+}
+
+.clear-search-btn {
+    position: absolute;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+}
+
+/* ==================================================
+   BOOKING CARDS
+   ================================================== */
+
+.bookings-container {
+    position: relative;
+}
+
+.bookings-list-container {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow-x: auto;
+    margin-bottom: 2rem;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.bookings-list-header,
+.booking-row {
+    display: grid;
+    grid-template-columns: 80px 2fr 2fr 1fr 1fr 1fr;
+    gap: 1rem;
+    align-items: center;
+}
+
+.bookings-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.booking-row {
+    display: grid;
+    grid-template-columns: 80px 2fr 2fr 1fr 1fr 1fr;
+    gap: 1rem;
+    padding: 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+    align-items: center;
+    transition: background-color 0.2s ease;
+}
+
+.booking-row:last-child {
+    border-bottom: none;
+}
+
+.booking-row:hover {
+    background: hsl(var(--muted) / 0.1);
+}
+
+.booking-cell {
+    font-size: 0.875rem;
+    color: hsl(var(--foreground));
+}
+
+.client-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.client-name {
+    font-weight: 500;
+}
+
+.client-email {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+}
+
+@media (max-width: 1024px) {
+    .bookings-list-header,
+    .booking-row {
+        grid-template-columns: 80px 2fr 1.5fr 1fr 1fr 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .bookings-list-container {
+        overflow-x: auto;
+        padding-bottom: 1rem;
+    }
+    .bookings-list-header,
+    .booking-row {
+        min-width: 700px;
+        font-size: 0.95em;
+    }
+    .client-info {
+        min-width: 120px;
+    }
+}
+
+@media (max-width: 600px) {
+    .bookings-list-header,
+    .booking-row {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        min-width: unset;
+        gap: 0.5rem;
+        padding: 0.75rem 0.5rem;
+    }
+    .bookings-list-header {
+        font-size: 1em;
+        background: hsl(var(--muted) / 0.2);
+        border-bottom: 1px solid hsl(var(--border));
+    }
+    .booking-row {
+        border-bottom: 1px solid hsl(var(--border));
+        background: hsl(var(--background));
+        margin-bottom: 0.5rem;
+        border-radius: 8px;
+        box-shadow: 0 1px 2px hsl(var(--border) / 0.1);
+    }
+    .booking-cell {
+        width: 100%;
+        font-size: 1em;
+        padding: 0.25rem 0;
+    }
+}
+
+/* ==================================================
+   EMPTY STATE
+   ================================================== */
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4rem 2rem;
+    margin: 2rem 0;
+    border-radius: 16px;
+    background: linear-gradient(135deg, hsl(var(--muted) / 0.3), hsl(var(--muted) / 0.1));
+    border: 2px dashed hsl(var(--border));
+}
+
+.empty-state-icon {
+    margin-bottom: 2rem;
+    opacity: 0.6;
+    color: hsl(var(--muted-foreground));
+}
+
+.empty-state-content h3 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 1rem 0;
+    color: hsl(var(--foreground));
+}
+
+.empty-state-content p {
+    font-size: 1rem;
+    color: hsl(var(--muted-foreground));
+    line-height: 1.6;
+    margin: 0 0 2rem 0;
+    max-width: 32rem;
+}
+
+.empty-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+/* ==================================================
+   PAGINATION
+   ================================================== */
+
+.pagination-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid hsl(var(--border));
+}
+
+.pagination-info {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.pagination-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.pagination-btn,
+.pagination-number {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    border-radius: 6px;
+    font-size: 0.875rem;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.pagination-btn:hover,
+.pagination-number:hover {
+    background: hsl(var(--accent));
+    border-color: hsl(var(--primary) / 0.3);
+}
+
+.pagination-number.current {
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
+    color: white;
+}
+
+.pagination-ellipsis {
+    padding: 0.5rem 0.75rem;
+    color: hsl(var(--muted-foreground));
+}
+
+/* ==================================================
+   MODALS
+   ================================================== */
+
+.mobooking-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background-color: rgb(0 0 0 / 0.8);
+    backdrop-filter: blur(8px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.mobooking-modal:not([style*="display: none"]) {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-content {
+    background-color: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    box-shadow: var(--shadow-xl);
+    width: 90vw;
+    max-width: 32rem;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+    margin: 1rem;
+    animation: modalSlideUp 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes modalSlideUp {
+    from {
+        opacity: 0;
+        transform: translateY(2rem) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.modal-header {
+    padding: 1.5rem 1.5rem 0 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+    padding: 0.25rem;
+    line-height: 1;
+    transition: color 0.2s ease;
+}
+
+.modal-close:hover {
+    color: hsl(var(--destructive));
+}
+
+.modal-body {
+    padding: 1.5rem;
+}
+
+.bulk-actions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.bulk-action-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: hsl(var(--muted-foreground));
+}
+
+.bulk-action-btn:hover {
+    border-color: hsl(var(--primary));
+    background: hsl(var(--primary) / 0.05);
+    color: hsl(var(--primary));
+    transform: translateY(-2px);
+}
+
+.confirm-bulk:hover {
+    border-color: hsl(var(--info));
+    background: hsl(var(--info) / 0.05);
+    color: hsl(var(--info));
+}
+
+.complete-bulk:hover {
+    border-color: hsl(var(--success));
+    background: hsl(var(--success) / 0.05);
+    color: hsl(var(--success));
+}
+
+.cancel-bulk:hover {
+    border-color: hsl(var(--destructive));
+    background: hsl(var(--destructive) / 0.05);
+    color: hsl(var(--destructive));
+}
+
+/* ==================================================
+   NOTIFICATIONS
+   ================================================== */
+
+.notification {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1000;
+    background: white;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    box-shadow: var(--shadow-lg);
+    max-width: 400px;
+    min-width: 300px;
+    transform: translateX(100%);
+    opacity: 0;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.notification.show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.notification-content {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.notification-message {
+    flex: 1;
+    font-size: 0.875rem;
+    color: hsl(var(--foreground));
+}
+
+.notification-close {
+    background: none;
+    border: none;
+    font-size: 1.25rem;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+    line-height: 1;
+    transition: color 0.2s ease;
+}
+
+.notification-close:hover {
+    color: hsl(var(--destructive));
+}
+
+.notification-success {
+    border-left: 4px solid hsl(var(--success));
+}
+
+.notification-error {
+    border-left: 4px solid hsl(var(--destructive));
+}
+
+.notification-info {
+    border-left: 4px solid hsl(var(--info));
+}
+
+.update-notification {
+    position: fixed;
+    top: 80px;
+    right: 20px;
+    z-index: 999;
+    background: hsl(var(--info));
+    color: white;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.875rem;
+}
+
+.refresh-btn {
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: white;
+    padding: 0.375rem 0.75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.refresh-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+/* ==================================================
+   RESPONSIVE DESIGN
+   ================================================== */
+
+@media (max-width: 1200px) {
+    .analytics-grid {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .bookings-list.cards-view {
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .header-content {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.5rem;
+    }
+
+    .header-actions {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .page-title {
+        font-size: 1.5rem;
+        justify-content: center;
+    }
+
+    .analytics-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .metric-value {
+        font-size: 1.75rem;
+    }
+
+    .controls-section {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.5rem;
+    }
+
+    .controls-left,
+    .controls-right {
+        justify-content: center;
+    }
+
+    .filters-container {
+        justify-content: center;
+    }
+
+    .filter-select,
+    .search-input {
+        min-width: auto;
+        width: 100%;
+    }
+
+    .bookings-list.cards-view {
+        grid-template-columns: 1fr;
+    }
+
+    .booking-main-info {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .service-date-section {
+        text-align: left;
+    }
+
+    .date-info {
+        align-items: flex-start;
+    }
+
+    .booking-secondary-info {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .price-section {
+        text-align: left;
+    }
+
+    .booking-card-footer {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    .booking-actions {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .pagination-container {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .pagination-controls {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .bulk-actions-grid {
+        grid-template-columns: 1fr;
+    }
+
+    /* Mobile swipe actions */
+    .booking-card.actions-visible .booking-actions {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@media (max-width: 480px) {
+    .title-icon {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+
+    .page-title {
+        font-size: 1.25rem;
+    }
+
+    .controls-section {
+        padding: 1rem;
+    }
+
+    .booking-card {
+        margin: 0 -0.5rem;
+    }
+
+    .booking-card-header,
+    .booking-card-body,
+    .booking-card-footer {
+        padding: 1rem;
+    }
+
+    .customer-avatar {
+        width: 2.5rem;
+        height: 2.5rem;
+        font-size: 0.75rem;
+    }
+
+    .action-btn {
+        padding: 0.375rem 0.5rem;
+        font-size: 0.6875rem;
+    }
+
+    .modal-content {
+        margin: 0.5rem;
+        max-height: 95vh;
+    }
+
+    .notification {
+        left: 0.5rem;
+        right: 0.5rem;
+        min-width: auto;
+        max-width: none;
+    }
+}
+
+/* ==================================================
+   ACCESSIBILITY & ANIMATIONS
+   ================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+@media (prefers-contrast: high) {
+    .booking-card,
+    .metric-card,
+    .action-btn,
+    .filter-select,
+    .search-input {
+        border-width: 2px;
+    }
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Focus styles for keyboard navigation */
+.booking-card:focus-within,
+.action-btn:focus,
+.filter-select:focus,
+.search-input:focus,
+.pagination-btn:focus,
+.pagination-number:focus {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+}
+
+/* Loading states */
+.loading {
+    position: relative;
+    pointer-events: none;
+}
+
+.loading::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid hsl(var(--primary) / 0.3);
+    border-top-color: hsl(var(--primary));
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: translate(-50%, -50%) rotate(360deg);
+    }
+}
+
+/* Print styles */
+@media print {
+    .header-actions,
+    .controls-section,
+    .booking-actions,
+    .pagination-container,
+    .notification,
+    .modal-content {
+        display: none !important;
+    }
+
+    .booking-card {
+        break-inside: avoid;
+        border: 2px solid #333;
+        margin-bottom: 1rem;
+    }
+
+    .bookings-list {
+        grid-template-columns: 1fr !important;
+        gap: 1rem;
+    }
+}
+
+/* Table Layout Styles */
+.bookings-table-container {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 2rem;
+}
+
+.bookings-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.bookings-table th,
+.bookings-table td {
+    padding: 1rem;
+    text-align: left;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.bookings-table th {
+    background: hsl(var(--muted) / 0.3);
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.bookings-table tr:last-child td {
+    border-bottom: none;
+}
+
+.bookings-table tr:hover {
+    background: hsl(var(--muted) / 0.1);
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.status-pending {
+    background: hsl(var(--warning) / 0.1);
+    color: hsl(var(--warning));
+}
+
+.status-confirmed {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+}
+
+.status-completed {
+    background: hsl(var(--info) / 0.1);
+    color: hsl(var(--info));
+}
+
+.status-cancelled {
+    background: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+}
+
+.btn-view-details {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.btn-view-details:hover {
+    background: hsl(var(--primary) / 0.9);
+    transform: translateY(-1px);
+}
+
+@media (max-width: 768px) {
+    .bookings-table-container {
+        overflow-x: auto;
+    }
+
+    .bookings-table {
+        min-width: 600px;
+    }
+}
+
+/* Div-based Table Layout Styles */
+.bookings-list-container {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 2rem;
+}
+
+.bookings-list-header {
+    display: grid;
+    grid-template-columns: 80px 2fr 2fr 1fr 1fr 1fr;
+    gap: 1rem;
+    padding: 1rem;
+    background: hsl(var(--muted) / 0.3);
+    border-bottom: 1px solid hsl(var(--border));
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.bookings-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.booking-row {
+    display: grid;
+    grid-template-columns: 80px 2fr 2fr 1fr 1fr 1fr;
+    gap: 1rem;
+    padding: 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+    align-items: center;
+    transition: background-color 0.2s ease;
+}
+
+.booking-row:last-child {
+    border-bottom: none;
+}
+
+.booking-row:hover {
+    background: hsl(var(--muted) / 0.1);
+}
+
+.booking-cell {
+    font-size: 0.875rem;
+    color: hsl(var(--foreground));
+}
+
+.client-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.client-name {
+    font-weight: 500;
+}
+
+.client-email {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.status-pending {
+    background: hsl(var(--warning) / 0.1);
+    color: hsl(var(--warning));
+}
+
+.status-confirmed {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+}
+
+.status-completed {
+    background: hsl(var(--info) / 0.1);
+    color: hsl(var(--info));
+}
+
+.status-cancelled {
+    background: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+}
+
+.btn-view-details {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.btn-view-details:hover {
+    background: hsl(var(--primary) / 0.9);
+    transform: translateY(-1px);
+}
+
+@media (max-width: 1024px) {
+    .bookings-list-header,
+    .booking-row {
+        grid-template-columns: 80px 2fr 1.5fr 1fr 1fr 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .bookings-list-container {
+        overflow-x: auto;
+    }
+
+    .bookings-list-header,
+    .booking-row {
+        min-width: 800px;
+    }
+
+    .client-info {
+        min-width: 200px;
+    }
+}
+</style>

--- a/page-discounts.php
+++ b/page-discounts.php
@@ -1,0 +1,3889 @@
+<?php
+// dashboard/sections/discounts.php - FIXED Discount Codes Management Section
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Initialize discounts manager
+try {
+    $discounts_manager = new \MoBooking\Discounts\Manager();
+} catch (Exception $e) {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking: Failed to initialize Discounts Manager: ' . $e->getMessage());
+    }
+    // Create a fallback to prevent fatal errors
+    $discounts_manager = new stdClass();
+    $discounts_manager->get_user_discounts = function() { return array(); };
+}
+
+// Get user's discount codes
+$discounts = is_callable(array($discounts_manager, 'get_user_discounts'))
+    ? $discounts_manager->get_user_discounts($user_id)
+    : array();
+
+// Get statistics
+$total_discounts = count($discounts);
+$active_discounts = count(array_filter($discounts, function($discount) { return $discount->active; }));
+$expired_discounts = count(array_filter($discounts, function($discount) {
+    return $discount->expiry_date && strtotime($discount->expiry_date) < time();
+}));
+$total_usage = array_sum(array_column($discounts, 'usage_count'));
+?>
+
+<div class="discounts-section">
+<!-- Page Header -->
+<div class="page-header">
+    <div class="header-content">
+        <div class="header-content-inner">
+
+          <div class="header-info">
+              <h1 class="page-title">
+                  <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                  </svg>
+                  <?php _e('Discount Codes', 'mobooking'); ?>
+              </h1>
+              <p class="page-subtitle"><?php _e('Create and manage discount codes for your services', 'mobooking'); ?></p>
+          </div>
+        </div>
+
+    <div class="header-actions">
+        <button type="button" id="add-discount-btn" class="btn-primary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 5v14M5 12h14"/>
+            </svg>
+            <?php _e('Create Discount Code', 'mobooking'); ?>
+        </button>
+    </div>
+    </div>
+
+</div>
+    <?php if (empty($discounts)) : ?>
+        <!-- Empty State -->
+        <div class="discounts-empty-state">
+            <div class="empty-state-visual">
+                <div class="empty-state-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                    </svg>
+                </div>
+                <div class="empty-state-sparkles">
+                    <div class="sparkle sparkle-1"></div>
+                    <div class="sparkle sparkle-2"></div>
+                    <div class="sparkle sparkle-3"></div>
+                </div>
+            </div>
+            <div class="empty-state-content">
+                <h2><?php _e('Boost Sales with Discount Codes', 'mobooking'); ?></h2>
+                <p><?php _e('Create promotional codes to attract new customers and reward loyal ones. Offer percentage or fixed amount discounts to increase bookings.', 'mobooking'); ?></p>
+                <button type="button" id="add-first-discount-btn" class="btn-primary btn-large">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 5v14M5 12h14"/>
+                    </svg>
+                    <?php _e('Create Your First Discount Code', 'mobooking'); ?>
+                </button>
+            </div>
+        </div>
+    <?php else : ?>
+        <!-- Discounts Management -->
+        <div class="discounts-management">
+
+
+        <div class="mobooking-metric-cards">
+            <div class="mobooking-stat-card mobooking-total-discounts">
+                <div class="mobooking-stat-card-header">
+                    <div class="mobooking-stat-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                        </svg>
+                    </div>
+                    <div class="mobooking-stat-info">
+                        <div class="mobooking-stat-value"><?php echo $total_discounts; ?></div>
+                        <div class="mobooking-stat-label"><?php _e('Total Codes', 'mobooking'); ?></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mobooking-stat-card mobooking-active-discounts">
+                <div class="mobooking-stat-card-header">
+                    <div class="mobooking-stat-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                        </svg>
+                    </div>
+                    <div class="mobooking-stat-info">
+                        <div class="mobooking-stat-value"><?php echo $active_discounts; ?></div>
+                        <div class="mobooking-stat-label"><?php _e('Active Codes', 'mobooking'); ?></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mobooking-stat-card mobooking-expired-discounts">
+                <div class="mobooking-stat-card-header">
+                    <div class="mobooking-stat-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <path d="M12 6v6l4 2"></path>
+                        </svg>
+                    </div>
+                    <div class="mobooking-stat-info">
+                        <div class="mobooking-stat-value"><?php echo $expired_discounts; ?></div>
+                        <div class="mobooking-stat-label"><?php _e('Expired', 'mobooking'); ?></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mobooking-stat-card mobooking-total-usage">
+                <div class="mobooking-stat-card-header">
+                    <div class="mobooking-stat-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                    </div>
+                    <div class="mobooking-stat-info">
+                        <div class="mobooking-stat-value"><?php echo $total_usage; ?></div>
+                        <div class="mobooking-stat-label"><?php _e('Total Uses', 'mobooking'); ?></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+
+            <!-- Filters and Actions -->
+            <div class="discounts-toolbar">
+                <div class="filters-section">
+                    <select id="discount-status-filter" class="filter-select">
+                        <option value=""><?php _e('All Statuses', 'mobooking'); ?></option>
+                        <option value="active"><?php _e('Active', 'mobooking'); ?></option>
+                        <option value="inactive"><?php _e('Inactive', 'mobooking'); ?></option>
+                        <option value="expired"><?php _e('Expired', 'mobooking'); ?></option>
+                    </select>
+
+                    <select id="discount-type-filter" class="filter-select">
+                        <option value=""><?php _e('All Types', 'mobooking'); ?></option>
+                        <option value="percentage"><?php _e('Percentage', 'mobooking'); ?></option>
+                        <option value="fixed"><?php _e('Fixed Amount', 'mobooking'); ?></option>
+                    </select>
+                </div>
+
+                <div class="search-section">
+                    <input type="text" id="discounts-search-input" placeholder="<?php _e('Search discount codes...', 'mobooking'); ?>" class="search-input">
+                </div>
+            </div>
+
+            <!-- Discounts Table -->
+            <div class="discounts-container">
+                <div class="discounts-grid-header">
+                    <div class="grid-header-cell discount-code"><?php _e('Code', 'mobooking'); ?></div>
+                    <div class="grid-header-cell discount-type"><?php _e('Type', 'mobooking'); ?></div>
+                    <div class="grid-header-cell discount-amount"><?php _e('Discount', 'mobooking'); ?></div>
+                    <div class="grid-header-cell usage-info"><?php _e('Usage', 'mobooking'); ?></div>
+                    <div class="grid-header-cell expiry-date"><?php _e('Expires', 'mobooking'); ?></div>
+                    <div class="grid-header-cell status"><?php _e('Status', 'mobooking'); ?></div>
+                    <div class="grid-header-cell actions"><?php _e('Actions', 'mobooking'); ?></div>
+                </div>
+
+                <div class="discounts-grid-body" id="discounts-list">
+                    <?php foreach ($discounts as $discount) :
+                        $is_expired = $discount->expiry_date && strtotime($discount->expiry_date) < time();
+                        $is_limit_reached = $discount->usage_limit > 0 && $discount->usage_count >= $discount->usage_limit;
+                        $effective_status = !$discount->active ? 'inactive' : ($is_expired ? 'expired' : 'active');
+                        $usage_percentage = $discount->usage_limit > 0 ? min(100, ($discount->usage_count / $discount->usage_limit) * 100) : 0;
+                    ?>
+                        <div class="discount-row" data-discount-id="<?php echo esc_attr($discount->id); ?>" data-status="<?php echo esc_attr($effective_status); ?>" data-type="<?php echo esc_attr($discount->type); ?>">
+                            <div class="grid-cell discount-code">
+                                <div class="code-display">
+                                    <span class="code-text"><?php echo esc_html($discount->code); ?></span>
+                                    <button class="copy-code-btn" data-code="<?php echo esc_attr($discount->code); ?>" title="<?php _e('Copy code', 'mobooking'); ?>">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+                                            <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div class="grid-cell discount-type">
+                                <span class="type-badge type-<?php echo esc_attr($discount->type); ?>">
+                                    <?php if ($discount->type === 'percentage') : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                                        </svg>
+                                        <?php _e('Percentage', 'mobooking'); ?>
+                                    <?php else : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <line x1="12" y1="1" x2="12" y2="23"></line>
+                                            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                        </svg>
+                                        <?php _e('Fixed Amount', 'mobooking'); ?>
+                                    <?php endif; ?>
+                                </span>
+                            </div>
+
+                            <div class="grid-cell discount-amount">
+                                <span class="amount-display">
+                                    <?php
+                                    if ($discount->type === 'percentage') {
+                                        echo number_format($discount->amount, 0) . '%';
+                                    } else {
+                                        echo function_exists('wc_price') ? wc_price($discount->amount) : '$' . number_format($discount->amount, 2);
+                                    }
+                                    ?>
+                                </span>
+                            </div>
+
+                            <div class="grid-cell usage-info">
+                                <div class="usage-display">
+                                    <div class="usage-numbers">
+                                        <span class="usage-count"><?php echo $discount->usage_count; ?></span>
+                                        <?php if ($discount->usage_limit > 0) : ?>
+                                            <span class="usage-separator">/</span>
+                                            <span class="usage-limit"><?php echo $discount->usage_limit; ?></span>
+                                        <?php else : ?>
+                                            <span class="usage-unlimited"><?php _e('unlimited', 'mobooking'); ?></span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <?php if ($discount->usage_limit > 0) : ?>
+                                        <div class="usage-progress">
+                                            <div class="usage-progress-bar">
+                                                <div class="usage-progress-fill" style="width: <?php echo $usage_percentage; ?>%"></div>
+                                            </div>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+
+                            <div class="grid-cell expiry-date">
+                                <?php if ($discount->expiry_date) : ?>
+                                    <div class="expiry-display">
+                                        <span class="expiry-date-text"><?php echo date_i18n(get_option('date_format'), strtotime($discount->expiry_date)); ?></span>
+                                        <?php if ($is_expired) : ?>
+                                            <span class="expiry-status expired"><?php _e('Expired', 'mobooking'); ?></span>
+                                        <?php else : ?>
+                                            <?php
+                                            $days_until_expiry = ceil((strtotime($discount->expiry_date) - time()) / (60 * 60 * 24));
+                                            if ($days_until_expiry <= 7) : ?>
+                                                <span class="expiry-status warning"><?php echo $days_until_expiry . ' ' . _n('day left', 'days left', $days_until_expiry, 'mobooking'); ?></span>
+                                            <?php endif; ?>
+                                        <?php endif; ?>
+                                    </div>
+                                <?php else : ?>
+                                    <span class="no-expiry"><?php _e('No expiry', 'mobooking'); ?></span>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="grid-cell status">
+                                <span class="status-badge status-<?php echo esc_attr($effective_status); ?>">
+                                    <?php
+                                    switch ($effective_status) {
+                                        case 'active':
+                                            echo '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/></svg>';
+                                            _e('Active', 'mobooking');
+                                            break;
+                                        case 'inactive':
+                                            echo '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><path d="M8 12h8"/></svg>';
+                                            _e('Inactive', 'mobooking');
+                                            break;
+                                        case 'expired':
+                                            echo '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><path d="M12 6v6l4 2"></path></svg>';
+                                            _e('Expired', 'mobooking');
+                                            break;
+                                    }
+                                    ?>
+                                </span>
+                                <?php if ($is_limit_reached) : ?>
+                                    <span class="limit-reached"><?php _e('Limit reached', 'mobooking'); ?></span>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="grid-cell actions">
+                                <div class="action-buttons">
+                                    <button type="button" class="btn-icon edit-discount-btn" data-discount-id="<?php echo esc_attr($discount->id); ?>" title="<?php _e('Edit', 'mobooking'); ?>">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                            <path d="m18.5 2.5-9.5 9.5L4 15l1-4 9.5-9.5 3 3Z"></path>
+                                        </svg>
+                                    </button>
+
+                                    <button type="button" class="btn-icon toggle-discount-btn" data-discount-id="<?php echo esc_attr($discount->id); ?>" data-active="<?php echo $discount->active ? '1' : '0'; ?>" title="<?php echo $discount->active ? __('Deactivate', 'mobooking') : __('Activate', 'mobooking'); ?>">
+                                        <?php if ($discount->active) : ?>
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <circle cx="12" cy="12" r="10"></circle>
+                                                <path d="M8 12h8"/>
+                                            </svg>
+                                        <?php else : ?>
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                                            </svg>
+                                        <?php endif; ?>
+                                    </button>
+
+                                    <button type="button" class="btn-icon btn-danger delete-discount-btn" data-discount-id="<?php echo esc_attr($discount->id); ?>" title="<?php _e('Delete', 'mobooking'); ?>">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="m3 6 3 18h12l3-18"></path>
+                                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+
+            <!-- Discount Code Generator -->
+            <div class="discount-generator">
+                <h3><?php _e('Quick Actions', 'mobooking'); ?></h3>
+                <div class="generator-actions">
+                    <button type="button" id="generate-welcome-discount" class="btn-secondary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                        <?php _e('Generate Welcome Discount', 'mobooking'); ?>
+                    </button>
+
+                    <button type="button" id="generate-holiday-discount" class="btn-secondary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                        </svg>
+                        <?php _e('Generate Holiday Discount', 'mobooking'); ?>
+                    </button>
+
+                    <button type="button" id="generate-bulk-discounts" class="btn-secondary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M17 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                        <?php _e('Bulk Generate Codes', 'mobooking'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+
+<!-- Discount Modal (Add/Edit) -->
+<div id="discount-modal" class="mobooking-modal" style="display:none;">
+    <div class="modal-backdrop"></div>
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3 id="discount-modal-title"><?php _e('Add Discount Code', 'mobooking'); ?></h3>
+            <button class="modal-close" aria-label="<?php _e('Close', 'mobooking'); ?>">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 6 6 18M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+
+        <form id="discount-form" method="post">
+            <input type="hidden" id="discount-id" name="id">
+            <?php wp_nonce_field('mobooking-discount-nonce', 'nonce'); ?>
+
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="discount-code"><?php _e('Discount Code', 'mobooking'); ?> *</label>
+                    <div class="input-with-button">
+                        <input type="text" id="discount-code" name="code" class="form-control"
+                               placeholder="<?php _e('e.g., SAVE20', 'mobooking'); ?>"
+                               pattern="[A-Z0-9]{3,20}"
+                               title="<?php _e('3-20 characters, letters and numbers only', 'mobooking'); ?>"
+                               required>
+                        <button type="button" id="generate-code-btn" class="btn-secondary">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="1 4 1 10 7 10"></polyline>
+                                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                            </svg>
+                            <?php _e('Generate', 'mobooking'); ?>
+                        </button>
+                    </div>
+                    <p class="field-help"><?php _e('Enter a unique code (3-20 characters, uppercase letters and numbers only)', 'mobooking'); ?></p>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="discount-type"><?php _e('Discount Type', 'mobooking'); ?> *</label>
+                        <select id="discount-type" name="type" class="form-control" required>
+                            <option value="percentage"><?php _e('Percentage', 'mobooking'); ?></option>
+                            <option value="fixed"><?php _e('Fixed Amount', 'mobooking'); ?></option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="discount-amount" id="discount-amount-label"><?php _e('Discount Amount', 'mobooking'); ?> *</label>
+                        <div class="amount-input-wrapper">
+                            <span class="amount-prefix" id="amount-prefix">%</span>
+                            <input type="number" id="discount-amount" name="amount" class="form-control"
+                                   min="0" max="100" step="0.01" required>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="discount-expiry"><?php _e('Expiry Date', 'mobooking'); ?></label>
+                        <input type="date" id="discount-expiry" name="expiry_date" class="form-control">
+                        <p class="field-help"><?php _e('Leave empty for no expiry date', 'mobooking'); ?></p>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="discount-usage-limit"><?php _e('Usage Limit', 'mobooking'); ?></label>
+                        <input type="number" id="discount-usage-limit" name="usage_limit" class="form-control"
+                               min="0" placeholder="<?php _e('Unlimited', 'mobooking'); ?>">
+                        <p class="field-help"><?php _e('Maximum number of times this code can be used', 'mobooking'); ?></p>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="discount-active" name="active" value="1" checked>
+                        <?php _e('Active (available for use)', 'mobooking'); ?>
+                    </label>
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <div class="form-actions">
+                    <button type="button" id="delete-discount-btn" class="btn-danger" style="display: none;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="m3 6 3 18h12l3-18"></path>
+                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
+                        </svg>
+                        <?php _e('Delete Discount', 'mobooking'); ?>
+                    </button>
+
+                    <div class="spacer"></div>
+
+                    <button type="button" id="cancel-discount-btn" class="btn-secondary">
+                        <?php _e('Cancel', 'mobooking'); ?>
+                    </button>
+
+                    <button type="submit" class="btn-primary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+                            <polyline points="17,21 17,13 7,13 7,21"/>
+                            <polyline points="7,3 7,8 15,8"/>
+                        </svg>
+                        <span class="btn-text"><?php _e('Save Discount', 'mobooking'); ?></span>
+                        <span class="btn-loading"><?php _e('Saving...', 'mobooking'); ?></span>
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<!-- Bulk Generator Modal -->
+<div id="bulk-generator-modal" class="mobooking-modal" style="display:none;">
+    <div class="modal-backdrop"></div>
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3><?php _e('Bulk Generate Discount Codes', 'mobooking'); ?></h3>
+            <button class="modal-close" aria-label="<?php _e('Close', 'mobooking'); ?>">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 6 6 18M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+
+        <form id="bulk-generator-form">
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="bulk-count"><?php _e('Number of Codes', 'mobooking'); ?> *</label>
+                    <input type="number" id="bulk-count" name="count" class="form-control"
+                           min="1" max="100" value="10" required>
+                    <p class="field-help"><?php _e('Generate up to 100 codes at once', 'mobooking'); ?></p>
+                </div>
+
+                <div class="form-group">
+                    <label for="bulk-prefix"><?php _e('Code Prefix', 'mobooking'); ?></label>
+                    <input type="text" id="bulk-prefix" name="prefix" class="form-control"
+                           placeholder="<?php _e('e.g., SAVE', 'mobooking'); ?>"
+                           pattern="[A-Z]{2,10}"
+                           title="<?php _e('2-10 uppercase letters only', 'mobooking'); ?>">
+                    <p class="field-help"><?php _e('Optional prefix for generated codes', 'mobooking'); ?></p>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="bulk-type"><?php _e('Discount Type', 'mobooking'); ?> *</label>
+                        <select id="bulk-type" name="type" class="form-control" required>
+                            <option value="percentage"><?php _e('Percentage', 'mobooking'); ?></option>
+                            <option value="fixed"><?php _e('Fixed Amount', 'mobooking'); ?></option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="bulk-amount"><?php _e('Discount Amount', 'mobooking'); ?> *</label>
+                        <div class="amount-input-wrapper">
+                            <span class="amount-prefix" id="bulk-amount-prefix">%</span>
+                            <input type="number" id="bulk-amount" name="amount" class="form-control"
+                                   min="0" max="100" step="0.01" required>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="bulk-expiry"><?php _e('Expiry Date', 'mobooking'); ?></label>
+                        <input type="date" id="bulk-expiry" name="expiry_date" class="form-control">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="bulk-usage-limit"><?php _e('Usage Limit (per code)', 'mobooking'); ?></label>
+                        <input type="number" id="bulk-usage-limit" name="usage_limit" class="form-control"
+                               min="0" value="1">
+                    </div>
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <div class="form-actions">
+                    <button type="button" class="btn-secondary cancel-bulk-btn">
+                        <?php _e('Cancel', 'mobooking'); ?>
+                    </button>
+
+                    <button type="submit" class="btn-primary">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M17 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+                            <circle cx="9" cy="7" r="4"></circle>
+                            <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"></path>
+                        </svg>
+                        <span class="btn-text"><?php _e('Generate Codes', 'mobooking'); ?></span>
+                        <span class="btn-loading"><?php _e('Generating...', 'mobooking'); ?></span>
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<!-- Confirmation Modal -->
+<div id="confirmation-modal" class="mobooking-modal" style="display:none;">
+    <div class="modal-backdrop"></div>
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3><?php _e('Confirm Action', 'mobooking'); ?></h3>
+        </div>
+        <div class="modal-body">
+            <p id="confirmation-message"><?php _e('Are you sure you want to perform this action?', 'mobooking'); ?></p>
+        </div>
+        <div class="modal-footer">
+            <div class="form-actions">
+                <button type="button" class="btn-secondary cancel-action-btn">
+                    <?php _e('Cancel', 'mobooking'); ?>
+                </button>
+                <button type="button" class="btn-danger confirm-action-btn">
+                    <span class="btn-text"><?php _e('Confirm', 'mobooking'); ?></span>
+                    <span class="btn-loading"><?php _e('Processing...', 'mobooking'); ?></span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+// Enqueue additional scripts and styles
+wp_enqueue_script('wp-color-picker');
+wp_enqueue_style('wp-color-picker');
+wp_enqueue_media();
+
+// Localize script for AJAX calls and translations
+$localize_data = array(
+    'ajaxUrl' => admin_url('admin-ajax.php'),
+    'nonce' => wp_create_nonce('mobooking-discount-nonce'),
+    'userId' => $user_id,
+    'strings' => array(
+        'saving' => __('Saving...', 'mobooking'),
+        'saved' => __('Discount saved successfully', 'mobooking'),
+        'error' => __('An error occurred', 'mobooking'),
+        'copied' => __('Copied to clipboard', 'mobooking'),
+        'confirmDelete' => __('Are you sure you want to delete this discount code? This action cannot be undone.', 'mobooking'),
+        'generating' => __('Generating codes...', 'mobooking'),
+        'generated' => __('Discount codes generated successfully', 'mobooking'),
+        'invalidCode' => __('Please enter a valid discount code (3-20 characters, letters and numbers only)', 'mobooking'),
+        'duplicateCode' => __('This discount code already exists', 'mobooking'),
+        'required' => __('This field is required', 'mobooking'),
+        'maxAmount' => __('Amount cannot exceed maximum value', 'mobooking'),
+        'invalidDate' => __('Please select a future date', 'mobooking'),
+        'addDiscount' => __('Add Discount Code', 'mobooking'),
+        'editDiscount' => __('Edit Discount Code', 'mobooking')
+    ),
+    'settings' => array(
+        'totalDiscounts' => $total_discounts,
+        'activeDiscounts' => $active_discounts,
+        'expiredDiscounts' => $expired_discounts,
+        'totalUsage' => $total_usage
+    )
+);
+
+wp_localize_script('mobooking-dashboard', 'mobookingDiscounts', $localize_data);
+?>
+
+
+
+
+
+
+
+
+<script>
+// FIXED DISCOUNTS JAVASCRIPT - ADDRESSING ALL POTENTIAL ISSUES
+jQuery(document).ready(function($) {
+    'use strict';
+
+    console.log('🚀 MoBooking Discounts Manager initializing...');
+
+    const DiscountsManager = {
+        // Configuration - Fixed potential undefined issues
+        config: {
+            ajaxUrl: (typeof mobookingDashboard !== 'undefined' && mobookingDashboard?.ajaxUrl) || '/wp-admin/admin-ajax.php',
+            nonces: (typeof mobookingDashboard !== 'undefined' && mobookingDashboard?.nonces) || {},
+            strings: (typeof mobookingDiscounts !== 'undefined' && mobookingDiscounts?.strings) || {}
+        },
+
+        // State
+        state: {
+            currentDiscountId: null,
+            isEditing: false,
+            pendingAction: null,
+            initialized: false
+        },
+
+        // Initialize with better error handling
+        init: function() {
+            console.log('DiscountsManager: Starting initialization...');
+
+            try {
+                // Check if required elements exist
+                if (!this.checkRequiredElements()) {
+                    console.error('DiscountsManager: Required elements not found, retrying in 500ms...');
+                    setTimeout(() => this.init(), 500);
+                    return;
+                }
+
+                this.attachEventListeners();
+                this.updateDiscountAmountInput();
+                this.setMinDate();
+                this.state.initialized = true;
+
+                console.log('✅ DiscountsManager: Initialized successfully');
+            } catch (error) {
+                console.error('DiscountsManager initialization error:', error);
+                setTimeout(() => this.init(), 1000); // Retry after 1 second
+            }
+        },
+
+        // Check if required DOM elements exist
+        checkRequiredElements: function() {
+            const requiredElements = [
+                '#add-discount-btn, #add-first-discount-btn',
+                '#discount-modal',
+                '#discount-form'
+            ];
+
+            for (const selector of requiredElements) {
+                if ($(selector).length === 0) {
+                    console.warn(`Required element not found: ${selector}`);
+                    return false;
+                }
+            }
+            return true;
+        },
+
+        // Attach event listeners with better error handling
+        attachEventListeners: function() {
+            const self = this;
+
+            try {
+                // Add discount buttons - Fixed selector issue
+                $(document).on('click', '#add-discount-btn, #add-first-discount-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Add discount button clicked');
+                    self.openAddDiscountModal();
+                });
+
+                // Edit discount buttons - Using event delegation
+                $(document).on('click', '.edit-discount-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Edit discount button clicked');
+                    const discountId = $(this).data('discount-id');
+                    if (discountId) {
+                        self.openEditDiscountModal(discountId);
+                    } else {
+                        console.error('No discount ID found');
+                    }
+                });
+
+                // Delete discount buttons
+                $(document).on('click', '.delete-discount-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Delete discount button clicked');
+                    const discountId = $(this).data('discount-id');
+                    if (discountId) {
+                        self.confirmDeleteDiscount(discountId);
+                    }
+                });
+
+                // Toggle discount status
+                $(document).on('click', '.toggle-discount-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Toggle discount button clicked');
+                    const discountId = $(this).data('discount-id');
+                    const isActive = $(this).data('active') == 1; // Fixed comparison
+                    if (discountId) {
+                        self.toggleDiscountStatus(discountId, !isActive);
+                    }
+                });
+
+                // Copy code buttons
+                $(document).on('click', '.copy-code-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Copy code button clicked');
+                    const code = $(this).data('code');
+                    if (code) {
+                        self.copyToClipboard(code);
+                    }
+                });
+
+                // Modal close buttons - Fixed selector
+                $(document).on('click', '.modal-close, #cancel-discount-btn, .cancel-bulk-btn, .cancel-action-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Modal close button clicked');
+                    self.closeModals();
+                });
+
+                // Modal backdrop clicks
+                $(document).on('click', '.modal-backdrop', function(e) {
+                    console.log('Modal backdrop clicked');
+                    self.closeModals();
+                });
+
+                // Prevent modal close when clicking inside modal content
+                $(document).on('click', '.modal-content', function(e) {
+                    e.stopPropagation();
+                });
+
+                // Discount type change
+                $(document).on('change', '#discount-type', function() {
+                    console.log('Discount type changed');
+                    self.updateDiscountAmountInput();
+                });
+
+                // Bulk type change
+                $(document).on('change', '#bulk-type', function() {
+                    console.log('Bulk type changed');
+                    self.updateBulkAmountInput();
+                });
+
+                // Generate code button
+                $(document).on('click', '#generate-code-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Generate code button clicked');
+                    self.generateDiscountCode();
+                });
+
+                // Quick action buttons
+                $(document).on('click', '#generate-welcome-discount', function(e) {
+                    e.preventDefault();
+                    console.log('Generate welcome discount clicked');
+                    self.generateWelcomeDiscount();
+                });
+
+                $(document).on('click', '#generate-holiday-discount', function(e) {
+                    e.preventDefault();
+                    console.log('Generate holiday discount clicked');
+                    self.generateHolidayDiscount();
+                });
+
+                $(document).on('click', '#generate-bulk-discounts', function(e) {
+                    e.preventDefault();
+                    console.log('Generate bulk discounts clicked');
+                    self.openBulkGeneratorModal();
+                });
+
+                // Form submissions
+                $(document).on('submit', '#discount-form', function(e) {
+                    e.preventDefault();
+                    console.log('Discount form submitted');
+                    self.saveDiscount();
+                });
+
+                $(document).on('submit', '#bulk-generator-form', function(e) {
+                    e.preventDefault();
+                    console.log('Bulk generator form submitted');
+                    self.generateBulkDiscounts();
+                });
+
+                // Confirmation action
+                $(document).on('click', '.confirm-action-btn', function(e) {
+                    e.preventDefault();
+                    console.log('Confirm action button clicked');
+                    self.executeConfirmedAction();
+                });
+
+                // Filters
+                $(document).on('change', '#discount-status-filter, #discount-type-filter', function() {
+                    console.log('Filter changed');
+                    self.filterDiscounts();
+                });
+
+                // Search - Using input event for real-time search
+                $(document).on('input', '#discounts-search-input', function() {
+                    console.log('Search input changed');
+                    self.searchDiscounts();
+                });
+
+                // Escape key to close modals
+                $(document).on('keydown', function(e) {
+                    if (e.key === 'Escape' || e.keyCode === 27) {
+                        console.log('Escape key pressed');
+                        self.closeModals();
+                    }
+                });
+
+                console.log('✅ DiscountsManager: Event listeners attached');
+
+            } catch (error) {
+                console.error('Error attaching event listeners:', error);
+            }
+        },
+
+        // Open add discount modal
+        openAddDiscountModal: function() {
+            try {
+                console.log('Opening add discount modal');
+                this.state.isEditing = false;
+                this.state.currentDiscountId = null;
+
+                const $modal = $('#discount-modal');
+                if ($modal.length === 0) {
+                    console.error('Discount modal not found');
+                    this.showNotification('Modal not found', 'error');
+                    return;
+                }
+
+                $('#discount-modal-title').text(this.config.strings.addDiscount || 'Add Discount Code');
+                $('#discount-form')[0].reset();
+                $('#discount-id').val('');
+                $('#discount-active').prop('checked', true);
+                $('#delete-discount-btn').hide();
+
+                this.updateDiscountAmountInput();
+                this.setMinDate();
+                this.showModal('#discount-modal');
+
+            } catch (error) {
+                console.error('Error opening add discount modal:', error);
+                this.showNotification('Error opening modal', 'error');
+            }
+        },
+
+        // Open edit discount modal - Fixed data extraction
+        openEditDiscountModal: function(discountId) {
+            try {
+                console.log('Opening edit discount modal for ID:', discountId);
+                this.state.isEditing = true;
+                this.state.currentDiscountId = discountId;
+
+                // Get discount data from the DOM
+                const $row = $(`.discount-row[data-discount-id="${discountId}"]`);
+                if ($row.length === 0) {
+                    console.error('Discount row not found for ID:', discountId);
+                    this.showNotification('Discount not found', 'error');
+                    return;
+                }
+
+                // Extract data more safely
+                const code = $row.find('.code-text').text().trim();
+                const type = $row.data('type') || 'percentage';
+                const amountText = $row.find('.amount-display').text().trim();
+
+                // Parse amount more robustly
+                let amount = 0;
+                if (type === 'percentage') {
+                    const match = amountText.match(/(\d+(?:\.\d+)?)/);
+                    amount = match ? parseFloat(match[1]) : 0;
+                } else {
+                    const match = amountText.match(/(\d+(?:\.\d+)?)/);
+                    amount = match ? parseFloat(match[1]) : 0;
+                }
+
+                // Get other data safely
+                const expiryElement = $row.find('.expiry-date-text');
+                const expiryText = expiryElement.length ? expiryElement.text().trim() : '';
+
+                const usageElement = $row.find('.usage-limit');
+                const usageText = usageElement.length ? usageElement.text().trim() : '';
+
+                const isActive = $row.find('.status-badge').hasClass('status-active');
+
+                // Fill form
+                $('#discount-modal-title').text(this.config.strings.editDiscount || 'Edit Discount Code');
+                $('#discount-id').val(discountId);
+                $('#discount-code').val(code);
+                $('#discount-type').val(type);
+                $('#discount-amount').val(amount);
+                $('#discount-active').prop('checked', isActive);
+
+                // Set usage limit if available
+                if (usageText && usageText !== 'unlimited') {
+                    const usageLimit = parseInt(usageText);
+                    if (!isNaN(usageLimit)) {
+                        $('#discount-usage-limit').val(usageLimit);
+                    }
+                } else {
+                    $('#discount-usage-limit').val('');
+                }
+
+                // Set expiry date if available
+                if (expiryText && expiryText !== 'No expiry') {
+                    try {
+                        const date = new Date(expiryText);
+                        if (!isNaN(date.getTime())) {
+                            const dateStr = date.toISOString().split('T')[0];
+                            $('#discount-expiry').val(dateStr);
+                        }
+                    } catch (e) {
+                        console.warn('Could not parse expiry date:', expiryText);
+                        $('#discount-expiry').val('');
+                    }
+                } else {
+                    $('#discount-expiry').val('');
+                }
+
+                $('#delete-discount-btn').show();
+                this.updateDiscountAmountInput();
+                this.showModal('#discount-modal');
+
+            } catch (error) {
+                console.error('Error opening edit discount modal:', error);
+                this.showNotification('Error opening edit modal', 'error');
+            }
+        },
+
+        // Save discount with better error handling
+        saveDiscount: function() {
+            try {
+                console.log('Saving discount...');
+                const $form = $('#discount-form');
+                const $submitBtn = $form.find('button[type="submit"]');
+
+                // Validate form
+                if (!this.validateDiscountForm()) {
+                    return;
+                }
+
+                // Disable form and show loading
+                this.setLoading($submitBtn, true);
+                $form.find('input, select, button').prop('disabled', true);
+
+                // Prepare form data
+                const discountId = $('#discount-id').val();
+                const postData = {
+                    action: 'mobooking_save_discount',
+                    nonce: this.config.nonces.discount || '',
+                    code: $('#discount-code').val().trim().toUpperCase(),
+                    type: $('#discount-type').val(),
+                    amount: parseFloat($('#discount-amount').val()),
+                    expiry_date: $('#discount-expiry').val(),
+                    usage_limit: $('#discount-usage-limit').val() || 0,
+                    active: $('#discount-active').is(':checked') ? 1 : 0
+                };
+
+                // Add ID for editing
+                if (discountId) {
+                    postData.id = discountId;
+                    postData.discount_id = discountId; // Send both formats
+                }
+
+                console.log('Save request data:', postData);
+
+                $.ajax({
+                    url: this.config.ajaxUrl,
+                    type: 'POST',
+                    data: postData,
+                    timeout: 30000, // 30 second timeout
+                    beforeSend: function(xhr) {
+                        console.log('Sending save request...');
+                    },
+                    success: (response) => {
+                        console.log('Save discount response:', response);
+                        try {
+                            if (response && response.success) {
+                                this.showNotification(response.data?.message || 'Discount saved successfully', 'success');
+                                this.closeModals();
+                                // Reload the page to show updated data
+                                setTimeout(() => {
+                                    window.location.reload();
+                                }, 1000);
+                            } else {
+                                console.error('Save failed:', response);
+                                this.showNotification(response?.data?.message || response?.data || 'Failed to save discount', 'error');
+                            }
+                        } catch (e) {
+                            console.error('Error parsing response:', e);
+                            this.showNotification('Invalid response from server', 'error');
+                        }
+                    },
+                    error: (xhr, status, error) => {
+                        console.error('Save discount error:', {xhr, status, error});
+                        console.error('Response text:', xhr.responseText);
+
+                        let errorMessage = 'Error saving discount';
+
+                        if (status === 'timeout') {
+                            errorMessage = 'Request timed out. Please try again.';
+                        } else {
+                            try {
+                                const errorResponse = JSON.parse(xhr.responseText);
+                                if (errorResponse.data) {
+                                    errorMessage = errorResponse.data;
+                                }
+                            } catch (e) {
+                                if (error) {
+                                    errorMessage += ': ' + error;
+                                }
+                            }
+                        }
+
+                        this.showNotification(errorMessage, 'error');
+                    },
+                    complete: () => {
+                        this.setLoading($submitBtn, false);
+                        $form.find('input, select, button').prop('disabled', false);
+                    }
+                });
+
+            } catch (error) {
+                console.error('Error in saveDiscount:', error);
+                this.showNotification('Error preparing save request', 'error');
+            }
+        },
+
+        // Rest of the methods remain the same but with better error handling...
+        confirmDeleteDiscount: function(discountId) {
+            try {
+                console.log('Confirming delete discount:', discountId);
+                this.state.pendingAction = {
+                    type: 'delete',
+                    discountId: discountId
+                };
+
+                const $codeElement = $(`.discount-row[data-discount-id="${discountId}"] .code-text`);
+                const code = $codeElement.length ? $codeElement.text().trim() : 'this discount';
+
+                $('#confirmation-message').text(
+                    `Are you sure you want to delete the discount code "${code}"? This action cannot be undone.`
+                );
+
+                this.showModal('#confirmation-modal');
+            } catch (error) {
+                console.error('Error in confirmDeleteDiscount:', error);
+                this.showNotification('Error preparing delete confirmation', 'error');
+            }
+        },
+
+        // Toggle discount status with better error handling
+        toggleDiscountStatus: function(discountId, newStatus) {
+            try {
+                console.log('Toggling discount status:', discountId, newStatus);
+                const $btn = $(`.toggle-discount-btn[data-discount-id="${discountId}"]`);
+
+                if ($btn.length === 0) {
+                    console.error('Toggle button not found for discount:', discountId);
+                    return;
+                }
+
+                this.setLoading($btn, true);
+
+                const postData = {
+                    action: 'mobooking_toggle_discount',
+                    id: discountId,
+                    discount_id: discountId, // Send both formats
+                    active: newStatus ? 1 : 0,
+                    nonce: this.config.nonces.discount || ''
+                };
+
+                console.log('Toggle request data:', postData);
+
+                $.ajax({
+                    url: this.config.ajaxUrl,
+                    type: 'POST',
+                    data: postData,
+                    timeout: 15000,
+                    beforeSend: function(xhr) {
+                        console.log('Sending toggle request...');
+                    },
+                    success: (response) => {
+                        console.log('Toggle discount response:', response);
+                        if (response && response.success) {
+                            this.showNotification(response.data?.message || 'Discount status updated', 'success');
+                            // Reload the page to show updated data
+                            setTimeout(() => {
+                                window.location.reload();
+                            }, 1000);
+                        } else {
+                            console.error('Toggle failed:', response);
+                            this.showNotification(response?.data?.message || response?.data || 'Failed to update discount status', 'error');
+                        }
+                    },
+                    error: (xhr, status, error) => {
+                        console.error('Toggle discount error:', {xhr, status, error});
+                        console.error('Response text:', xhr.responseText);
+
+                        let errorMessage = 'Error updating discount status';
+                        try {
+                            const errorResponse = JSON.parse(xhr.responseText);
+                            if (errorResponse.data) {
+                                errorMessage = errorResponse.data;
+                            }
+                        } catch (e) {
+                            // Keep default error message
+                        }
+
+                        this.showNotification(errorMessage, 'error');
+                    },
+                    complete: () => {
+                        this.setLoading($btn, false);
+                    }
+                });
+
+            } catch (error) {
+                console.error('Error in toggleDiscountStatus:', error);
+                this.showNotification('Error toggling discount status', 'error');
+            }
+        },
+
+        // Execute confirmed action
+        executeConfirmedAction: function() {
+            try {
+                console.log('Executing confirmed action:', this.state.pendingAction);
+                if (!this.state.pendingAction) {
+                    console.error('No pending action found');
+                    return;
+                }
+
+                const action = this.state.pendingAction;
+                const $btn = $('.confirm-action-btn');
+
+                this.setLoading($btn, true);
+
+                if (action.type === 'delete' && action.discountId) {
+                    console.log('Sending delete request for discount ID:', action.discountId);
+
+                    // Prepare the data object
+                    const postData = {
+                        action: 'mobooking_delete_discount',
+                        id: action.discountId, // Try both 'id' and 'discount_id'
+                        discount_id: action.discountId,
+                        nonce: this.config.nonces.discount || ''
+                    };
+
+                    console.log('Delete request data:', postData);
+
+                    $.ajax({
+                        url: this.config.ajaxUrl,
+                        type: 'POST',
+                        data: postData,
+                        timeout: 15000,
+                        beforeSend: function(xhr) {
+                            console.log('Sending delete request...');
+                        },
+                        success: (response) => {
+                            console.log('Delete discount response:', response);
+                            if (response && response.success) {
+                                this.showNotification(response.data?.message || 'Discount deleted successfully', 'success');
+                                this.closeModals();
+                                // Reload the page to show updated data
+                                setTimeout(() => {
+                                    window.location.reload();
+                                }, 1000);
+                            } else {
+                                console.error('Delete failed:', response);
+                                this.showNotification(response?.data?.message || response?.data || 'Failed to delete discount', 'error');
+                            }
+                        },
+                        error: (xhr, status, error) => {
+                            console.error('Delete discount error:', {xhr, status, error});
+                            console.error('Response text:', xhr.responseText);
+
+                            let errorMessage = 'Error deleting discount';
+                            try {
+                                const errorResponse = JSON.parse(xhr.responseText);
+                                if (errorResponse.data) {
+                                    errorMessage = errorResponse.data;
+                                }
+                            } catch (e) {
+                                // Keep default error message
+                            }
+
+                            this.showNotification(errorMessage, 'error');
+                        },
+                        complete: () => {
+                            this.setLoading($btn, false);
+                            this.state.pendingAction = null;
+                        }
+                    });
+                } else {
+                    console.error('Invalid delete action or missing discount ID:', action);
+                    this.showNotification('Invalid delete request', 'error');
+                    this.setLoading($btn, false);
+                    this.state.pendingAction = null;
+                }
+            } catch (error) {
+                console.error('Error executing confirmed action:', error);
+                this.showNotification('Error executing action', 'error');
+                this.setLoading($('.confirm-action-btn'), false);
+                this.state.pendingAction = null;
+            }
+        },
+
+        // Generate discount code
+        generateDiscountCode: function() {
+            try {
+                console.log('Generating discount code');
+                const prefixes = ['SAVE', 'DEAL', 'OFF', 'SPECIAL', 'PROMO'];
+                const prefix = prefixes[Math.floor(Math.random() * prefixes.length)];
+                const number = Math.floor(Math.random() * 90) + 10; // 10-99
+                const code = prefix + number;
+
+                $('#discount-code').val(code);
+                this.showNotification('Code generated: ' + code, 'success');
+            } catch (error) {
+                console.error('Error generating discount code:', error);
+                this.showNotification('Error generating code', 'error');
+            }
+        },
+
+        // Generate welcome discount
+        generateWelcomeDiscount: function() {
+            try {
+                console.log('Generating welcome discount');
+                this.openAddDiscountModal();
+
+                // Set values after modal is open
+                setTimeout(() => {
+                    $('#discount-code').val('WELCOME10');
+                    $('#discount-type').val('percentage');
+                    $('#discount-amount').val('10');
+
+                    // Set expiry to 30 days from now
+                    const date = new Date();
+                    date.setDate(date.getDate() + 30);
+                    $('#discount-expiry').val(date.toISOString().split('T')[0]);
+
+                    this.updateDiscountAmountInput();
+                }, 100);
+
+            } catch (error) {
+                console.error('Error generating welcome discount:', error);
+                this.showNotification('Error generating welcome discount', 'error');
+            }
+        },
+
+        // Generate holiday discount
+        generateHolidayDiscount: function() {
+            try {
+                console.log('Generating holiday discount');
+                const holidays = ['HOLIDAY', 'XMAS', 'NEWYEAR', 'SUMMER', 'SPRING'];
+                const holiday = holidays[Math.floor(Math.random() * holidays.length)];
+                const amount = [15, 20, 25][Math.floor(Math.random() * 3)];
+
+                this.openAddDiscountModal();
+
+                // Set values after modal is open
+                setTimeout(() => {
+                    $('#discount-code').val(holiday + amount);
+                    $('#discount-type').val('percentage');
+                    $('#discount-amount').val(amount.toString());
+                    this.updateDiscountAmountInput();
+                }, 100);
+
+            } catch (error) {
+                console.error('Error generating holiday discount:', error);
+                this.showNotification('Error generating holiday discount', 'error');
+            }
+        },
+
+        // Copy to clipboard with fallback
+        copyToClipboard: function(text) {
+            try {
+                console.log('Copying to clipboard:', text);
+                if (navigator.clipboard && window.isSecureContext) {
+                    navigator.clipboard.writeText(text).then(() => {
+                        this.showNotification('Code copied to clipboard!', 'success');
+                    }).catch(() => {
+                        this.fallbackCopy(text);
+                    });
+                } else {
+                    this.fallbackCopy(text);
+                }
+            } catch (error) {
+                console.error('Error copying to clipboard:', error);
+                this.fallbackCopy(text);
+            }
+        },
+
+        // Fallback copy method
+        fallbackCopy: function(text) {
+            try {
+                const textArea = document.createElement('textarea');
+                textArea.value = text;
+                textArea.style.position = 'fixed';
+                textArea.style.left = '-999999px';
+                textArea.style.top = '-999999px';
+                document.body.appendChild(textArea);
+                textArea.focus();
+                textArea.select();
+
+                const successful = document.execCommand('copy');
+                document.body.removeChild(textArea);
+
+                if (successful) {
+                    this.showNotification('Code copied to clipboard!', 'success');
+                } else {
+                    this.showNotification('Please manually copy: ' + text, 'info');
+                }
+            } catch (err) {
+                console.error('Fallback copy failed:', err);
+                this.showNotification('Copy failed. Code: ' + text, 'error');
+            }
+        },
+
+        // Filter discounts
+        filterDiscounts: function() {
+            try {
+                console.log('Filtering discounts');
+                const statusFilter = $('#discount-status-filter').val();
+                const typeFilter = $('#discount-type-filter').val();
+
+                $('.discount-row').each(function() {
+                    const $row = $(this);
+                    const rowStatus = $row.data('status');
+                    const rowType = $row.data('type');
+
+                    let showRow = true;
+
+                    if (statusFilter && statusFilter !== rowStatus) {
+                        showRow = false;
+                    }
+
+                    if (typeFilter && typeFilter !== rowType) {
+                        showRow = false;
+                    }
+
+                    $row.toggle(showRow);
+                });
+            } catch (error) {
+                console.error('Error filtering discounts:', error);
+            }
+        },
+
+        // Search discounts
+        searchDiscounts: function() {
+            try {
+                console.log('Searching discounts');
+                const searchTerm = $('#discounts-search-input').val().toLowerCase();
+
+                $('.discount-row').each(function() {
+                    const $row = $(this);
+                    const code = $row.find('.code-text').text().toLowerCase();
+                    const showRow = !searchTerm || code.includes(searchTerm);
+                    $row.toggle(showRow);
+                });
+            } catch (error) {
+                console.error('Error searching discounts:', error);
+            }
+        },
+
+        // Update discount amount input
+        updateDiscountAmountInput: function() {
+            try {
+                const type = $('#discount-type').val();
+                const $prefix = $('#amount-prefix');
+                const $input = $('#discount-amount');
+                const $label = $('#discount-amount-label');
+
+                if (type === 'percentage') {
+                    $prefix.text('%');
+                    $input.attr('max', '100').attr('step', '1');
+                    if ($label.length) $label.text('Discount Percentage');
+                } else {
+                    $prefix.text('$');
+                    $input.attr('max', '10000').attr('step', '0.01');
+                    if ($label.length) $label.text('Discount Amount');
+                }
+            } catch (error) {
+                console.error('Error updating discount amount input:', error);
+            }
+        },
+
+        // Update bulk amount input
+        updateBulkAmountInput: function() {
+            try {
+                const type = $('#bulk-type').val();
+                const $prefix = $('#bulk-amount-prefix');
+                const $input = $('#bulk-amount');
+
+                if (type === 'percentage') {
+                    $prefix.text('%');
+                    $input.attr('max', '100').attr('step', '1');
+                } else {
+                    $prefix.text('$');
+                    $input.attr('max', '10000').attr('step', '0.01');
+                }
+            } catch (error) {
+                console.error('Error updating bulk amount input:', error);
+            }
+        },
+
+        // Set minimum date
+        setMinDate: function() {
+            try {
+                const today = new Date().toISOString().split('T')[0];
+                $('#discount-expiry, #bulk-expiry').attr('min', today);
+            } catch (error) {
+                console.error('Error setting minimum date:', error);
+            }
+        },
+
+        // Validate discount form
+        validateDiscountForm: function() {
+            try {
+                const code = $('#discount-code').val().trim();
+                const amount = parseFloat($('#discount-amount').val());
+                const type = $('#discount-type').val();
+
+                if (!code) {
+                    this.showNotification('Please enter a discount code', 'error');
+                    $('#discount-code').focus();
+                    return false;
+                }
+
+                if (!/^[A-Z0-9]{3,20}$/.test(code)) {
+                    this.showNotification('Code must be 3-20 characters, uppercase letters and numbers only', 'error');
+                    $('#discount-code').focus();
+                    return false;
+                }
+
+                if (!amount || amount <= 0) {
+                    this.showNotification('Please enter a valid discount amount', 'error');
+                    $('#discount-amount').focus();
+                    return false;
+                }
+
+                if (type === 'percentage' && amount > 100) {
+                    this.showNotification('Percentage discount cannot exceed 100%', 'error');
+                    $('#discount-amount').focus();
+                    return false;
+                }
+
+                const expiryDate = $('#discount-expiry').val();
+                if (expiryDate) {
+                    const today = new Date();
+                    const expiry = new Date(expiryDate);
+                    if (expiry <= today) {
+                        this.showNotification('Expiry date must be in the future', 'error');
+                        $('#discount-expiry').focus();
+                        return false;
+                    }
+                }
+
+                return true;
+            } catch (error) {
+                console.error('Error validating form:', error);
+                this.showNotification('Error validating form', 'error');
+                return false;
+            }
+        },
+
+        // Show modal
+        showModal: function(modalId) {
+            try {
+                console.log('Showing modal:', modalId);
+                const $modal = $(modalId);
+                if ($modal.length === 0) {
+                    console.error('Modal not found:', modalId);
+                    return;
+                }
+
+                $modal.show().css('display', 'flex');
+                $('body').addClass('modal-open');
+
+                // Focus first input
+                setTimeout(() => {
+                    $modal.find('input:visible:first').focus();
+                }, 100);
+            } catch (error) {
+                console.error('Error showing modal:', error);
+            }
+        },
+
+        // Close modals
+        closeModals: function() {
+            try {
+                console.log('Closing modals');
+                $('.mobooking-modal').hide();
+                $('body').removeClass('modal-open');
+                this.state.pendingAction = null;
+            } catch (error) {
+                console.error('Error closing modals:', error);
+            }
+        },
+
+        // Set loading state
+        setLoading: function($button, loading) {
+            try {
+                if (!$button || $button.length === 0) {
+                    console.warn('Button not found for loading state');
+                    return;
+                }
+
+                if (loading) {
+                    $button.addClass('loading').prop('disabled', true);
+                    const $btnText = $button.find('.btn-text');
+                    const $btnLoading = $button.find('.btn-loading');
+
+                    if ($btnText.length) $btnText.hide();
+                    if ($btnLoading.length) $btnLoading.show();
+                } else {
+                    $button.removeClass('loading').prop('disabled', false);
+                    const $btnText = $button.find('.btn-text');
+                    const $btnLoading = $button.find('.btn-loading');
+
+                    if ($btnText.length) $btnText.show();
+                    if ($btnLoading.length) $btnLoading.hide();
+                }
+            } catch (error) {
+                console.error('Error setting loading state:', error);
+            }
+        },
+
+        // Open bulk generator modal
+        openBulkGeneratorModal: function() {
+            try {
+                console.log('Opening bulk generator modal');
+                const $modal = $('#bulk-generator-modal');
+                if ($modal.length === 0) {
+                    console.error('Bulk generator modal not found');
+                    this.showNotification('Bulk generator not available', 'error');
+                    return;
+                }
+
+                $('#bulk-generator-form')[0].reset();
+                $('#bulk-count').val('10');
+                $('#bulk-amount').val('');
+                $('#bulk-usage-limit').val('1');
+                this.updateBulkAmountInput();
+                this.showModal('#bulk-generator-modal');
+            } catch (error) {
+                console.error('Error opening bulk generator modal:', error);
+                this.showNotification('Error opening bulk generator', 'error');
+            }
+        },
+
+        // Generate bulk discounts
+        generateBulkDiscounts: function() {
+            try {
+                console.log('Generating bulk discounts');
+                const $form = $('#bulk-generator-form');
+                const $submitBtn = $form.find('button[type="submit"]');
+
+                // Validate form
+                const count = parseInt($('#bulk-count').val());
+                const amount = parseFloat($('#bulk-amount').val());
+
+                if (!count || count < 1 || count > 100) {
+                    this.showNotification('Please enter a valid count (1-100)', 'error');
+                    $('#bulk-count').focus();
+                    return;
+                }
+
+                if (!amount || amount <= 0) {
+                    this.showNotification('Please enter a valid amount', 'error');
+                    $('#bulk-amount').focus();
+                    return;
+                }
+
+                // Disable form and show loading
+                this.setLoading($submitBtn, true);
+                $form.find('input, select, button').prop('disabled', true);
+
+                const formData = {
+                    action: 'mobooking_generate_bulk_discounts',
+                    nonce: this.config.nonces.discount || '',
+                    count: count,
+                    prefix: $('#bulk-prefix').val().trim().toUpperCase(),
+                    type: $('#bulk-type').val(),
+                    amount: amount,
+                    expiry_date: $('#bulk-expiry').val(),
+                    usage_limit: parseInt($('#bulk-usage-limit').val()) || 1
+                };
+
+                $.ajax({
+                    url: this.config.ajaxUrl,
+                    type: 'POST',
+                    data: formData,
+                    timeout: 60000, // 60 second timeout for bulk operations
+                    success: (response) => {
+                        console.log('Bulk generate response:', response);
+                        if (response && response.success) {
+                            this.showNotification(response.data?.message || 'Bulk discounts generated successfully', 'success');
+                            this.closeModals();
+                            // Reload the page to show new data
+                            setTimeout(() => {
+                                window.location.reload();
+                            }, 1000);
+                        } else {
+                            this.showNotification(response?.data?.message || 'Failed to generate bulk discounts', 'error');
+                        }
+                    },
+                    error: (xhr, status, error) => {
+                        console.error('Bulk generate error:', {xhr, status, error});
+                        let errorMessage = 'Error generating bulk discounts';
+
+                        if (status === 'timeout') {
+                            errorMessage = 'Request timed out. Please try with fewer codes.';
+                        } else if (xhr.responseJSON?.data?.message) {
+                            errorMessage = xhr.responseJSON.data.message;
+                        }
+
+                        this.showNotification(errorMessage, 'error');
+                    },
+                    complete: () => {
+                        this.setLoading($submitBtn, false);
+                        $form.find('input, select, button').prop('disabled', false);
+                    }
+                });
+
+            } catch (error) {
+                console.error('Error in generateBulkDiscounts:', error);
+                this.showNotification('Error preparing bulk generation', 'error');
+            }
+        },
+
+        // Show notification with better error handling
+        showNotification: function(message, type = 'info') {
+            try {
+                console.log('Showing notification:', message, type);
+
+                // Remove existing notifications
+                $('.discount-notification').remove();
+
+                const colors = {
+                    success: '#22c55e',
+                    error: '#ef4444',
+                    warning: '#f59e0b',
+                    info: '#3b82f6'
+                };
+
+                const icons = {
+                    success: '✓',
+                    error: '✗',
+                    warning: '⚠',
+                    info: 'ℹ'
+                };
+
+                const $notification = $(`
+                    <div class="discount-notification ${type}" style="
+                        position: fixed;
+                        top: 20px;
+                        right: 20px;
+                        z-index: 10000;
+                        min-width: 300px;
+                        max-width: 500px;
+                        padding: 16px 20px;
+                        background: ${colors[type] || colors.info};
+                        color: white;
+                        border-radius: 8px;
+                        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+                        transform: translateX(100%);
+                        opacity: 0;
+                        transition: all 0.3s ease;
+                        display: flex;
+                        align-items: center;
+                        gap: 12px;
+                        font-weight: 500;
+                        font-size: 14px;
+                        line-height: 1.4;
+                    ">
+                        <span style="font-size: 18px; font-weight: bold; flex-shrink: 0;">${icons[type] || icons.info}</span>
+                        <span style="flex: 1;">${message}</span>
+                        <button style="
+                            background: rgba(255, 255, 255, 0.2);
+                            border: none;
+                            color: white;
+                            width: 24px;
+                            height: 24px;
+                            border-radius: 50%;
+                            cursor: pointer;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            font-size: 18px;
+                            flex-shrink: 0;
+                            font-weight: bold;
+                        " onclick="$(this).parent().remove()">×</button>
+                    </div>
+                `);
+
+                $('body').append($notification);
+
+                // Show notification with animation
+                setTimeout(() => {
+                    $notification.css({
+                        transform: 'translateX(0)',
+                        opacity: 1
+                    });
+                }, 100);
+
+                // Auto-hide after delay (except for errors)
+                const hideDelay = type === 'error' ? 8000 : 5000;
+                setTimeout(() => {
+                    if ($notification.length) {
+                        $notification.css({
+                            transform: 'translateX(100%)',
+                            opacity: 0
+                        });
+                        setTimeout(() => $notification.remove(), 300);
+                    }
+                }, hideDelay);
+
+            } catch (error) {
+                console.error('Error showing notification:', error);
+                // Fallback to alert
+                alert(message);
+            }
+        }
+    };
+
+    // Initialize with delay to ensure DOM is ready
+    setTimeout(() => {
+        DiscountsManager.init();
+    }, 100);
+
+    // Fallback initialization if first attempt fails
+    setTimeout(() => {
+        if (!DiscountsManager.state.initialized) {
+            console.warn('🔄 Retrying DiscountsManager initialization...');
+            DiscountsManager.init();
+        }
+    }, 1000);
+
+    // Make it globally available for debugging
+    window.MoBookingDiscountsManager = DiscountsManager;
+
+    console.log('✅ MoBooking Discounts Manager script loaded');
+});
+</script>
+
+
+
+<style>
+/* FIXED DISCOUNTS SECTION CSS - COMPREHENSIVE STYLING */
+
+/* CSS Variables for better theming and consistency */
+:root {
+  --primary: 220 70% 50%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96%;
+  --secondary-foreground: 222.2 84% 4.9%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 94%;
+  --accent-foreground: 222.2 84% 4.9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --radius: 8px;
+
+  /* Success colors */
+  --success: 142 76% 36%;
+  --success-foreground: 355.7 100% 97.3%;
+
+  /* Warning colors */
+  --warning: 32 95% 44%;
+  --warning-foreground: 48 96% 89%;
+
+  /* Info colors */
+  --info: 217 91% 60%;
+  --info-foreground: 213 31% 91%;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 84% 4.9%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+  }
+}
+
+/* Base styles and reset */
+.discounts-section {
+  animation: fadeInUp 0.5s ease-out;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+.discounts-section * {
+  box-sizing: border-box;
+}
+
+/* Animation keyframes */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes bounce {
+  0%, 20%, 53%, 80%, 100% {
+    animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+    transform: translate3d(0,0,0);
+  }
+  40%, 43% {
+    animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    transform: translate3d(0, -30px, 0);
+  }
+  70% {
+    animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    transform: translate3d(0, -15px, 0);
+  }
+  90% {
+    transform: translate3d(0,-4px,0);
+  }
+}
+
+@keyframes sparkle {
+  0%, 100% {
+    opacity: 0;
+    transform: scale(0) rotate(0deg);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1) rotate(180deg);
+  }
+}
+
+@keyframes successPulse {
+  0% {
+    transform: scale(1);
+    background: rgba(34, 197, 94, 0.2);
+  }
+  50% {
+    transform: scale(1.02);
+    background: rgba(34, 197, 94, 0.15);
+  }
+  100% {
+    transform: scale(1);
+    background: rgba(34, 197, 94, 0.1);
+  }
+}
+
+/* Header Section */
+.discounts-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2rem;
+  padding: 2rem;
+  background: linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--muted)) 100%);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.discounts-header-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 3rem;
+  flex: 1;
+}
+
+.discounts-title-group {
+  flex: 1;
+}
+
+.discounts-main-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: hsl(var(--foreground));
+  line-height: 1.2;
+}
+
+.title-icon {
+  width: 32px;
+  height: 32px;
+  color: hsl(var(--primary));
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+}
+
+.discounts-subtitle {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  font-size: 1.1rem;
+  font-weight: 400;
+}
+
+.discounts-stats {
+  display: flex;
+  gap: 2rem;
+}
+
+.stat-item {
+  text-align: center;
+  padding: 0.5rem;
+}
+
+.stat-number {
+  display: block;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: hsl(var(--primary));
+  line-height: 1;
+  margin-bottom: 0.25rem;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground));
+  font-weight: 500;
+}
+
+.discounts-header-actions {
+  align-self: flex-start;
+}
+
+/* Stats Grid */
+.discounts-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, hsl(var(--primary)), hsl(var(--primary) / 0.8));
+  transform: scaleX(0);
+  transition: transform 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 30px hsl(var(--primary) / 0.15);
+  border-color: hsl(var(--primary) / 0.3);
+}
+
+.stat-card:hover::before {
+  transform: scaleX(1);
+}
+
+.stat-card-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.stat-icon {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, hsl(var(--primary) / 0.1), hsl(var(--primary) / 0.05));
+  color: hsl(var(--primary));
+  flex-shrink: 0;
+  transition: all 0.3s ease;
+}
+
+.stat-card:hover .stat-icon {
+  background: linear-gradient(135deg, hsl(var(--primary) / 0.2), hsl(var(--primary) / 0.1));
+  transform: scale(1.1);
+}
+
+.stat-icon svg {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.stat-info {
+  flex: 1;
+}
+
+.stat-value {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: hsl(var(--foreground));
+  line-height: 1;
+  margin-bottom: 0.25rem;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground));
+  font-weight: 500;
+}
+
+/* Toolbar */
+.discounts-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+  background: hsl(var(--muted) / 0.5);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  backdrop-filter: blur(8px);
+}
+
+.filters-section {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.filter-select,
+.search-input {
+  padding: 0.625rem 0.875rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: calc(var(--radius) - 2px);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-size: 0.875rem;
+  transition: all 0.2s ease;
+}
+
+.filter-select {
+  min-width: 160px;
+}
+
+.filter-select:focus,
+.search-input:focus {
+  outline: none;
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0 3px hsl(var(--primary) / 0.1);
+  transform: translateY(-1px);
+}
+
+.search-section {
+  flex: 1;
+  max-width: 320px;
+  position: relative;
+}
+
+.search-input {
+  width: 100%;
+  padding-left: 2.5rem;
+}
+
+.search-section::before {
+  content: '🔍';
+  position: absolute;
+  left: 0.875rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+  z-index: 1;
+}
+
+/* Discounts Container */
+.discounts-container {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.discounts-grid-header {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1.5fr 1.5fr 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: linear-gradient(135deg, hsl(var(--muted)), hsl(var(--muted) / 0.8));
+  border-bottom: 1px solid hsl(var(--border));
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.discounts-grid-body {
+  max-height: 600px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+}
+
+.discounts-grid-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.discounts-grid-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.discounts-grid-body::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground) / 0.3);
+  border-radius: 4px;
+}
+
+.discounts-grid-body::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.5);
+}
+
+.discount-row {
+  display: grid;
+  grid-template-columns:2fr 1.5fr 1fr 1fr 1.5fr 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid hsl(var(--border) / 0.5);
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.discount-row:hover {
+  background: hsl(var(--muted) / 0.3);
+}
+
+.discount-row:last-child {
+  border-bottom: none;
+}
+
+.discount-row.loading {
+  opacity: 0.6;
+  pointer-events: none;
+  position: relative;
+}
+
+.discount-row.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  border: 2px solid hsl(var(--muted-foreground) / 0.3);
+  border-radius: 50%;
+  border-top-color: hsl(var(--primary));
+  animation: spin 1s linear infinite;
+}
+
+.discount-row.success {
+  background: rgba(34, 197, 94, 0.1);
+  animation: successPulse 0.6s ease-out;
+}
+
+.grid-cell {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+  min-height: 2.5rem;
+}
+
+/* Code Display */
+.code-display {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.code-text {
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-weight: 600;
+  background: linear-gradient(135deg, hsl(var(--muted)), hsl(var(--muted) / 0.5));
+  padding: 0.375rem 0.75rem;
+  border-radius: calc(var(--radius) - 2px);
+  color: hsl(var(--primary));
+  font-size: 0.8rem;
+  border: 1px solid hsl(var(--border));
+  transition: all 0.2s ease;
+}
+
+.code-display:hover .code-text {
+  background: linear-gradient(135deg, hsl(var(--primary) / 0.1), hsl(var(--primary) / 0.05));
+  border-color: hsl(var(--primary) / 0.3);
+}
+
+.copy-code-btn {
+  padding: 0.375rem;
+  border: none;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  border-radius: calc(var(--radius) - 2px);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.copy-code-btn:hover {
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  transform: scale(1.1);
+}
+
+.copy-code-btn:active {
+  transform: scale(0.95);
+}
+
+.copy-code-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Badges */
+.type-badge,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid;
+  transition: all 0.2s ease;
+}
+
+.type-badge svg,
+.status-badge svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Type badges */
+.type-badge.type-percentage {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.1), rgba(34, 197, 94, 0.05));
+  color: #16a34a;
+  border-color: rgba(34, 197, 94, 0.2);
+}
+
+.type-badge.type-fixed {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(59, 130, 246, 0.05));
+  color: #2563eb;
+  border-color: rgba(59, 130, 246, 0.2);
+}
+
+/* Status badges */
+.status-badge.status-active {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.1), rgba(34, 197, 94, 0.05));
+  color: #16a34a;
+  border-color: rgba(34, 197, 94, 0.2);
+}
+
+.status-badge.status-inactive {
+  background: linear-gradient(135deg, rgba(107, 114, 128, 0.1), rgba(107, 114, 128, 0.05));
+  color: #6b7280;
+  border-color: rgba(107, 114, 128, 0.2);
+}
+
+.status-badge.status-expired {
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.1), rgba(239, 68, 68, 0.05));
+  color: #dc2626;
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+/* Amount Display */
+.amount-display {
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  font-size: 0.9rem;
+}
+
+/* Usage Display */
+.usage-display {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.usage-numbers {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.usage-count {
+  font-weight: 600;
+  color: hsl(var(--primary));
+}
+
+.usage-separator {
+  color: hsl(var(--muted-foreground));
+}
+
+.usage-limit {
+  color: hsl(var(--muted-foreground));
+}
+
+.usage-unlimited {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  font-style: italic;
+}
+
+.usage-progress {
+  width: 100%;
+  max-width: 80px;
+}
+
+.usage-progress-bar {
+  width: 100%;
+  height: 4px;
+  background: hsl(var(--muted));
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.usage-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, hsl(var(--primary)), hsl(var(--primary) / 0.8));
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+/* Expiry Display */
+.expiry-display {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.expiry-date-text {
+  font-size: 0.875rem;
+  color: hsl(var(--foreground));
+  font-weight: 500;
+}
+
+.expiry-status {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.125rem 0.5rem;
+  border-radius: 12px;
+  display: inline-block;
+  width: fit-content;
+}
+
+.expiry-status.expired {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.expiry-status.warning {
+  background: rgba(245, 158, 11, 0.1);
+  color: #d97706;
+}
+
+.no-expiry {
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground));
+  font-style: italic;
+}
+
+.limit-reached {
+  display: block;
+  font-size: 0.65rem;
+  color: #f59e0b;
+  font-weight: 500;
+  margin-top: 0.125rem;
+  padding: 0.125rem 0.375rem;
+  background: rgba(245, 158, 11, 0.1);
+  border-radius: 8px;
+  width: fit-content;
+}
+
+/* Action Buttons */
+.action-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn-icon {
+  padding: 0.5rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--background));
+  border-radius: calc(var(--radius) - 2px);
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--muted-foreground));
+  position: relative;
+  overflow: hidden;
+}
+
+.btn-icon::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  background: hsl(var(--primary) / 0.1);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  transition: all 0.3s ease;
+}
+
+.btn-icon:hover::before {
+  width: 100%;
+  height: 100%;
+}
+
+.btn-icon:hover {
+  border-color: hsl(var(--primary) / 0.5);
+  color: hsl(var(--primary));
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px hsl(var(--primary) / 0.2);
+}
+
+.btn-icon:active {
+  transform: translateY(0);
+}
+
+.btn-icon svg {
+  width: 16px;
+  height: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.btn-icon.btn-danger {
+  border-color: hsl(var(--destructive) / 0.3);
+  color: hsl(var(--destructive));
+}
+
+.btn-icon.btn-danger::before {
+  background: hsl(var(--destructive) / 0.1);
+}
+
+.btn-icon.btn-danger:hover {
+  border-color: hsl(var(--destructive));
+  color: hsl(var(--destructive));
+  box-shadow: 0 4px 12px hsl(var(--destructive) / 0.2);
+}
+
+/* Buttons */
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border: 1px solid;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  text-decoration: none;
+  position: relative;
+  overflow: hidden;
+  user-select: none;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.9));
+  border-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  box-shadow: 0 2px 4px hsl(var(--primary) / 0.2);
+}
+
+.btn-primary:hover {
+  background: linear-gradient(135deg, hsl(var(--primary) / 0.9), hsl(var(--primary) / 0.8));
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px hsl(var(--primary) / 0.3);
+}
+
+.btn-primary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px hsl(var(--primary) / 0.2);
+}
+
+.btn-secondary {
+  background: hsl(var(--secondary));
+  border-color: hsl(var(--border));
+  color: hsl(var(--secondary-foreground));
+}
+
+.btn-secondary:hover {
+  background: hsl(var(--accent));
+  border-color: hsl(var(--primary) / 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, hsl(var(--destructive)), hsl(var(--destructive) / 0.9));
+  border-color: hsl(var(--destructive));
+  color: hsl(var(--destructive-foreground));
+  box-shadow: 0 2px 4px hsl(var(--destructive) / 0.2);
+}
+
+.btn-danger:hover {
+  background: linear-gradient(135deg, hsl(var(--destructive) / 0.9), hsl(var(--destructive) / 0.8));
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px hsl(var(--destructive) / 0.3);
+}
+
+.btn-large {
+  padding: 1rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.btn-primary svg,
+.btn-secondary svg,
+.btn-danger svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* BUTTON LOADING STATES CSS */
+
+/* Base loading class for buttons */
+.loading {
+  pointer-events: none;
+  opacity: 0.8;
+  position: relative;
+}
+
+/* Hide normal button text when loading */
+.loading .btn-text {
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* Show loading content */
+.btn-loading {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.loading .btn-loading {
+  display: inline-flex;
+}
+
+/* Loading spinner - Method 1: CSS-only spinner */
+.btn-loading::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: rgba(255, 255, 255, 0.8);
+  animation: btn-spin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+/* For secondary buttons - darker spinner */
+.btn-secondary.loading .btn-loading::before {
+  border-color: rgba(0, 0, 0, 0.2);
+  border-top-color: rgba(0, 0, 0, 0.6);
+}
+
+/* For danger buttons - maintain white spinner */
+.btn-danger.loading .btn-loading::before {
+  border-color: rgba(255, 255, 255, 0.3);
+  border-top-color: rgba(255, 255, 255, 0.8);
+}
+
+/* Spin animation */
+@keyframes btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Alternative Method 2: Loading with text and spinner */
+.btn-loading-alt {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.loading .btn-loading-alt {
+  display: inline-flex;
+}
+
+.btn-loading-alt .spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid transparent;
+  border-top: 2px solid currentColor;
+  border-radius: 50%;
+  animation: btn-spin 1s linear infinite;
+}
+
+/* Method 3: Dots loading animation */
+.btn-loading-dots {
+  display: none;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.loading .btn-loading-dots {
+  display: inline-flex;
+}
+
+.btn-loading-dots .dot {
+  width: 4px;
+  height: 4px;
+  background: currentColor;
+  border-radius: 50%;
+  animation: btn-dot-bounce 1.4s infinite ease-in-out both;
+}
+
+.btn-loading-dots .dot:nth-child(1) { animation-delay: -0.32s; }
+.btn-loading-dots .dot:nth-child(2) { animation-delay: -0.16s; }
+.btn-loading-dots .dot:nth-child(3) { animation-delay: 0s; }
+
+@keyframes btn-dot-bounce {
+  0%, 80%, 100% {
+    transform: scale(0);
+    opacity: 0.5;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* Method 4: Pulse loading */
+.btn-loading-pulse {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.loading .btn-loading-pulse {
+  display: inline-flex;
+}
+
+.btn-loading-pulse .pulse-circle {
+  width: 8px;
+  height: 8px;
+  background: currentColor;
+  border-radius: 50%;
+  animation: btn-pulse 1.5s infinite;
+}
+
+@keyframes btn-pulse {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.5);
+    opacity: 0.3;
+  }
+}
+
+/* Enhanced loading states for different button sizes */
+
+/* Large buttons */
+.btn-large.loading .btn-loading::before {
+  width: 20px;
+  height: 20px;
+  border-width: 3px;
+}
+
+/* Small buttons */
+.btn-sm.loading .btn-loading::before {
+  width: 12px;
+  height: 12px;
+  border-width: 1.5px;
+}
+
+/* Icon buttons loading state */
+.btn-icon.loading {
+  opacity: 0.7;
+}
+
+.btn-icon.loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 50%;
+  border-top-color: rgba(0, 0, 0, 0.6);
+  animation: btn-spin 1s linear infinite;
+}
+
+.btn-icon.btn-danger.loading::after {
+  border-color: rgba(239, 68, 68, 0.3);
+  border-top-color: rgba(239, 68, 68, 0.8);
+}
+
+/* Disable hover effects when loading */
+.loading:hover {
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+/* Loading overlay for buttons */
+.btn-loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: inherit;
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.loading .btn-loading-overlay {
+  display: flex;
+}
+
+.btn-loading-overlay .spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: rgba(255, 255, 255, 0.8);
+  animation: btn-spin 1s linear infinite;
+}
+
+/* Form submit button specific loading */
+.form-submit-loading {
+  position: relative;
+  pointer-events: none;
+}
+
+.form-submit-loading .btn-text {
+  opacity: 0.3;
+}
+
+.form-submit-loading::after {
+  content: "";
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: rgba(255, 255, 255, 0.8);
+  animation: btn-spin 1s linear infinite;
+}
+
+/* Smooth transitions for loading states */
+.btn-text,
+.btn-loading {
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+/* Loading state for different themes */
+
+/* Dark mode loading adjustments */
+@media (prefers-color-scheme: dark) {
+  .btn-secondary.loading .btn-loading::before {
+    border-color: rgba(255, 255, 255, 0.2);
+    border-top-color: rgba(255, 255, 255, 0.6);
+  }
+
+  .btn-icon.loading::after {
+    border-color: rgba(255, 255, 255, 0.2);
+    border-top-color: rgba(255, 255, 255, 0.6);
+  }
+}
+
+/* High contrast mode */
+@media (prefers-contrast: high) {
+  .loading .btn-loading::before,
+  .btn-icon.loading::after {
+    border-width: 3px;
+  }
+}
+
+/* Reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .btn-loading::before,
+  .btn-loading-alt .spinner,
+  .btn-icon.loading::after,
+  .btn-loading-overlay .spinner {
+    animation: none;
+  }
+
+  /* Show static loading indicator instead */
+  .loading .btn-loading::before {
+    content: "⏳";
+    border: none;
+    width: auto;
+    height: auto;
+    font-size: 16px;
+  }
+
+  .btn-loading-dots .dot {
+    animation: none;
+    opacity: 0.6;
+  }
+
+  .btn-loading-pulse .pulse-circle {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* Specific loading states for common actions */
+.saving .btn-loading::after {
+  content: " Saving...";
+}
+
+.deleting .btn-loading::after {
+  content: " Deleting...";
+}
+
+.generating .btn-loading::after {
+  content: " Generating...";
+}
+
+.processing .btn-loading::after {
+  content: " Processing...";
+}
+
+/* Button loading with progress indication */
+.btn-progress {
+  position: relative;
+  overflow: hidden;
+}
+
+.btn-progress::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.2),
+    transparent
+  );
+  animation: btn-progress-shine 2s infinite;
+}
+
+@keyframes btn-progress-shine {
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+/* Loading button with percentage */
+.btn-loading-percent {
+  position: relative;
+}
+
+
+
+
+.btn-loading-percent::after {
+  content: attr(data-progress) "%";
+  position: absolute;
+  right: 0.75rem;
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+/* Disabled state during loading */
+.loading,
+.loading:hover,
+.loading:focus,
+.loading:active {
+  cursor: not-allowed;
+  user-select: none;
+}
+
+/* Loading button group styles */
+.btn-group .loading {
+  z-index: 1;
+}
+
+.btn-group .loading:not(:first-child) {
+  border-left-color: transparent;
+}
+
+.btn-group .loading:not(:last-child) {
+  border-right-color: transparent;
+}
+/* Modal Styles */
+.mobooking-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.modal-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+  animation: fadeIn 0.3s ease-out;
+}
+
+.modal-content {
+  position: relative;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  transform: scale(0.95);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.mobooking-modal[style*="flex"] .modal-content {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.modal-header {
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid hsl(var(--border));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(135deg, hsl(var(--muted) / 0.5), hsl(var(--muted) / 0.3));
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.modal-close {
+  padding: 0.5rem;
+  border: none;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  border-radius: calc(var(--radius) - 2px);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-close:hover {
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  transform: scale(1.1);
+}
+
+.modal-close svg {
+  width: 20px;
+  height: 20px;
+}
+
+.modal-body {
+  padding: 2rem;
+}
+
+.modal-footer {
+  padding: 1.5rem 2rem;
+  border-top: 1px solid hsl(var(--border));
+  background: hsl(var(--muted) / 0.3);
+  border-bottom-left-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+}
+
+/* Form Styles */
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group:last-child {
+  margin-bottom: 0;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  font-size: 0.875rem;
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: calc(var(--radius) - 2px);
+  font-size: 0.875rem;
+  transition: all 0.2s ease;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0 3px hsl(var(--primary) / 0.1);
+  transform: translateY(-1px);
+}
+
+.form-control:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: hsl(var(--muted) / 0.5);
+}
+
+.form-control.error {
+  border-color: hsl(var(--destructive));
+  box-shadow: 0 0 0 3px hsl(var(--destructive) / 0.1);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.input-with-button {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.input-with-button input {
+  flex: 1;
+}
+
+.amount-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.amount-prefix {
+  position: absolute;
+  left: 1rem;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+  z-index: 1;
+  font-size: 0.875rem;
+}
+
+.amount-input-wrapper input {
+  padding-left: 2.5rem;
+}
+
+.field-help {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  margin-top: 0.375rem;
+  line-height: 1.4;
+}
+
+.field-error {
+  color: hsl(var(--destructive));
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.field-error::before {
+  content: '⚠';
+  font-size: 0.875rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  padding: 1rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: calc(var(--radius) - 2px);
+  transition: all 0.2s ease;
+  background: hsl(var(--background));
+}
+
+.checkbox-label:hover {
+  background: hsl(var(--muted) / 0.5);
+  border-color: hsl(var(--primary) / 0.5);
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: hsl(var(--primary));
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.spacer {
+  flex: 1;
+}
+
+/* Empty State */
+.discounts-empty-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: linear-gradient(135deg, hsl(var(--muted) / 0.3), hsl(var(--muted) / 0.1));
+  border-radius: var(--radius);
+  border: 2px dashed hsl(var(--border));
+}
+
+.empty-state-visual {
+  position: relative;
+  display: inline-block;
+  margin-bottom: 2rem;
+}
+
+.empty-state-icon {
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, hsl(var(--primary) / 0.15), hsl(var(--primary) / 0.05));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.empty-state-icon::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(45deg, transparent, hsl(var(--primary) / 0.1), transparent);
+  animation: shimmer 2s infinite;
+}
+
+@keyframes shimmer {
+  0% { transform: translateX(-100%) translateY(-100%) rotate(45deg); }
+  100% { transform: translateX(100%) translateY(100%) rotate(45deg); }
+}
+
+.empty-state-icon svg {
+  width: 2.5rem;
+  height: 2.5rem;
+  color: hsl(var(--primary));
+  position: relative;
+  z-index: 1;
+}
+
+.empty-state-sparkles {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
+.sparkle {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: hsl(var(--primary));
+  border-radius: 50%;
+  animation: sparkle 2s infinite ease-in-out;
+}
+
+.sparkle-1 {
+  top: 10%;
+  right: 15%;
+  animation-delay: 0s;
+}
+
+.sparkle-2 {
+  top: 60%;
+  right: 10%;
+  animation-delay: 0.7s;
+}
+
+.sparkle-3 {
+  top: 20%;
+  left: 10%;
+  animation-delay: 1.4s;
+}
+
+.empty-state-content h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  margin-bottom: 0.75rem;
+}
+
+.empty-state-content p {
+  color: hsl(var(--muted-foreground));
+  max-width: 500px;
+  margin: 0 auto 2rem;
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+/* Discount Generator */
+.discount-generator {
+  margin-top: 2rem;
+  padding: 2rem;
+  background: linear-gradient(135deg, hsl(var(--muted) / 0.5), hsl(var(--muted) / 0.3));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+}
+
+.discount-generator h3 {
+  margin: 0 0 1.5rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.generator-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.generator-actions .btn-secondary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.generator-actions svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Notification Styles */
+.discount-notification {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 10000;
+  min-width: 320px;
+  max-width: 500px;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+  transform: translateX(100%);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: white;
+  backdrop-filter: blur(8px);
+}
+
+.discount-notification.success {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.discount-notification.error {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+}
+
+.discount-notification.warning {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+}
+
+.discount-notification.info {
+  background: linear-gradient(135deg, #3b82f6, #2563eb);
+}
+
+.discount-notification button {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  color: white;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  flex-shrink: 0;
+  font-weight: bold;
+  transition: all 0.2s ease;
+}
+
+.discount-notification button:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(1.1);
+}
+
+/* Utility Classes */
+.text-success { color: hsl(var(--success)) !important; }
+.text-error { color: hsl(var(--destructive)) !important; }
+.text-warning { color: hsl(var(--warning)) !important; }
+.text-info { color: hsl(var(--info)) !important; }
+
+.bg-success { background-color: hsl(var(--success) / 0.1) !important; }
+.bg-error { background-color: hsl(var(--destructive) / 0.1) !important; }
+.bg-warning { background-color: hsl(var(--warning) / 0.1) !important; }
+.bg-info { background-color: hsl(var(--info) / 0.1) !important; }
+
+/* Body Modal Open State */
+body.modal-open {
+  overflow: hidden;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+  .discounts-grid-header,
+  .discount-row {
+    grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 0.8fr 0.8fr;
+    font-size: 0.8rem;
+    gap: 0.75rem;
+    padding: 0.875rem 1.25rem;
+  }
+
+  .discounts-main-title {
+    font-size: 1.75rem;
+  }
+
+  .stat-value {
+    font-size: 1.875rem;
+  }
+}
+
+@media (max-width: 968px) {
+  .discounts-header {
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.5rem;
+  }
+
+  .discounts-header-content {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .discounts-stats {
+    align-self: center;
+    justify-content: center;
+  }
+
+  .discounts-header-actions {
+    align-self: stretch;
+  }
+
+  .discounts-toolbar {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .filters-section {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .search-section {
+    max-width: none;
+  }
+
+  .discounts-stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .generator-actions {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 768px) {
+  /* Mobile table transformation */
+  .discounts-grid-header {
+    display: none;
+  }
+
+  .discount-row {
+    display: block;
+    padding: 1.25rem;
+    border-bottom: 1px solid hsl(var(--border));
+    margin-bottom: 1rem;
+    border-radius: var(--radius);
+    background: hsl(var(--card));
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border: 1px solid hsl(var(--border));
+  }
+
+  .discount-row:hover {
+    transform: none;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .discount-row .grid-cell {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid hsl(var(--border) / 0.3);
+    margin: 0;
+  }
+
+  .discount-row .grid-cell:last-child {
+    border-bottom: none;
+    justify-content: flex-end;
+    padding-top: 1rem;
+  }
+
+  .discount-row .grid-cell::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    min-width: 80px;
+  }
+
+  /* Add data labels for mobile */
+  .discount-row .discount-code { --label: "Code"; }
+  .discount-row .discount-type { --label: "Type"; }
+  .discount-row .discount-amount { --label: "Amount"; }
+  .discount-row .usage-info { --label: "Usage"; }
+  .discount-row .expiry-date { --label: "Expires"; }
+  .discount-row .status { --label: "Status"; }
+
+  .discount-row .discount-code::before { content: "Code"; }
+  .discount-row .discount-type::before { content: "Type"; }
+  .discount-row .discount-amount::before { content: "Amount"; }
+  .discount-row .usage-info::before { content: "Usage"; }
+  .discount-row .expiry-date::before { content: "Expires"; }
+  .discount-row .status::before { content: "Status"; }
+
+  .action-buttons {
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+  }
+
+  .modal-content {
+    margin: 0.5rem;
+    max-height: calc(100vh - 1rem);
+  }
+
+  .modal-header,
+  .modal-body,
+  .modal-footer {
+    padding: 1rem 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .discounts-main-title {
+    font-size: 1.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .title-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .discounts-stats {
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+    width: 100%;
+  }
+
+  .stat-item {
+    padding: 0.75rem;
+    background: hsl(var(--muted) / 0.3);
+    border-radius: calc(var(--radius) - 2px);
+    border: 1px solid hsl(var(--border));
+  }
+
+  .empty-state-content {
+    padding: 0 1rem;
+  }
+
+  .empty-state-content h2 {
+    font-size: 1.25rem;
+  }
+
+  .btn-large {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .discounts-stats-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .stat-card {
+    padding: 1.25rem;
+  }
+
+  .stat-value {
+    font-size: 1.75rem;
+  }
+
+  .filters-section {
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .filter-select {
+    width: 100%;
+  }
+
+  .discount-notification {
+    left: 1rem;
+    right: 1rem;
+    min-width: auto;
+    max-width: none;
+  }
+}
+
+/* High Contrast Mode Support */
+@media (prefers-contrast: high) {
+  .type-badge,
+  .status-badge,
+  .expiry-status {
+    border-width: 2px;
+    font-weight: 600;
+  }
+
+  .code-text {
+    border: 2px solid hsl(var(--primary));
+  }
+
+  .usage-progress-bar {
+    border: 1px solid hsl(var(--border));
+  }
+
+  .btn-primary,
+  .btn-danger {
+    border-width: 2px;
+  }
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .sparkle {
+    animation: none;
+    opacity: 0.5;
+  }
+
+  .empty-state-icon::before {
+    animation: none;
+  }
+}
+
+/* Print Styles */
+@media print {
+  .discounts-header-actions,
+  .discounts-toolbar,
+  .action-buttons,
+  .generator-actions,
+  .modal-close,
+  .discount-notification {
+    display: none !important;
+  }
+
+  .discount-row {
+    page-break-inside: avoid;
+  }
+
+  .discounts-section {
+    background: white !important;
+    color: black !important;
+  }
+
+  .mobooking-modal {
+    display: none !important;
+  }
+
+  .discount-row:hover {
+    background: transparent !important;
+    transform: none !important;
+  }
+}
+
+/* Focus Styles for Accessibility */
+.copy-code-btn:focus,
+.btn-icon:focus,
+.btn-primary:focus,
+.btn-secondary:focus,
+.btn-danger:focus,
+.modal-close:focus {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+}
+
+.filter-select:focus,
+.search-input:focus,
+.form-control:focus {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+}
+
+/* Custom Scrollbar Styles */
+.discounts-container {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+}
+
+.discounts-container::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.discounts-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.discounts-container::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground) / 0.3);
+  border-radius: 4px;
+}
+
+.discounts-container::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.5);
+}
+
+/* Loading Overlay */
+.discounts-section.loading {
+  position: relative;
+  pointer-events: none;
+}
+
+.discounts-section.loading::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.discounts-section.loading::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border: 4px solid hsl(var(--muted));
+  border-radius: 50%;
+  border-top-color: hsl(var(--primary));
+  animation: spin 1s linear infinite;
+  z-index: 101;
+}
+
+/* Smooth transitions for dynamic content */
+.discount-row {
+  opacity: 1;
+  transition: opacity 0.3s ease, transform 0.2s ease;
+}
+
+.discount-row.hidden {
+  opacity: 0;
+  transform: translateX(-20px);
+}
+
+.discount-row.removing {
+  opacity: 0;
+  transform: translateX(100%);
+  transition: all 0.3s ease;
+}
+
+/* Enhanced focus indicators */
+.btn-primary:focus-visible,
+.btn-secondary:focus-visible,
+.btn-danger:focus-visible {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px hsl(var(--primary) / 0.2);
+}
+
+/* Improved mobile touch targets */
+@media (max-width: 768px) {
+  .btn-icon {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0.75rem;
+  }
+
+  .copy-code-btn {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0.75rem;
+  }
+
+  .modal-close {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0.75rem;
+  }
+}
+
+/* Enhanced empty state animation */
+.empty-state-visual {
+  animation: bounce 2s infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .empty-state-visual {
+    animation: none;
+  }
+}
+</style>

--- a/page-overview.php
+++ b/page-overview.php
@@ -1,0 +1,910 @@
+<?php
+// dashboard/sections/overview.php - Complete Dashboard Overview Section
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Initialize managers and get data
+try {
+    $bookings_manager = new \MoBooking\Bookings\Manager();
+    $services_manager = new \MoBooking\Services\ServicesManager();
+    $geography_manager = new \MoBooking\Geography\Manager();
+} catch (Throwable $e) { // Changed Exception to Throwable
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking: Failed to initialize managers in overview: ' . $e->getMessage());
+    }
+    // Create fallback objects
+    $bookings_manager = new stdClass();
+    $services_manager = new stdClass();
+    $geography_manager = new stdClass();
+}
+
+// Get dashboard stats - with error handling
+$stats = array(
+    'total_bookings' => 0,
+    'pending_bookings' => 0,
+    'confirmed_bookings' => 0,
+    'completed_bookings' => 0,
+    'total_revenue' => 0,
+    'this_month_revenue' => 0,
+    'this_week_revenue' => 0,
+    'today_revenue' => 0,
+    'most_popular_service' => null
+);
+
+try {
+    if (method_exists($bookings_manager, 'count_user_bookings')) {
+        $stats['total_bookings'] = $bookings_manager->count_user_bookings($user_id);
+        $stats['pending_bookings'] = $bookings_manager->count_user_bookings($user_id, 'pending');
+        $stats['confirmed_bookings'] = $bookings_manager->count_user_bookings($user_id, 'confirmed');
+        $stats['completed_bookings'] = $bookings_manager->count_user_bookings($user_id, 'completed');
+    }
+
+    if (method_exists($bookings_manager, 'calculate_user_revenue')) {
+        $stats['total_revenue'] = $bookings_manager->calculate_user_revenue($user_id);
+        $stats['this_month_revenue'] = $bookings_manager->calculate_user_revenue($user_id, 'this_month');
+        $stats['this_week_revenue'] = $bookings_manager->calculate_user_revenue($user_id, 'this_week');
+        $stats['today_revenue'] = $bookings_manager->calculate_user_revenue($user_id, 'today');
+    }
+
+    if (method_exists($bookings_manager, 'get_most_popular_service')) {
+        $stats['most_popular_service'] = $bookings_manager->get_most_popular_service($user_id);
+    }
+} catch (Exception $e) {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking: Error getting stats: ' . $e->getMessage());
+    }
+}
+
+// Get recent bookings
+$recent_bookings = array();
+try {
+    if (method_exists($bookings_manager, 'get_user_bookings')) {
+        $recent_bookings = $bookings_manager->get_user_bookings($user_id, array('limit' => 5, 'order' => 'DESC'));
+    }
+} catch (Exception $e) {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking: Error getting recent bookings: ' . $e->getMessage());
+    }
+}
+
+// Get user services
+$user_services = array();
+try {
+    if (method_exists($services_manager, 'get_user_services')) {
+        $user_services = $services_manager->get_user_services($user_id);
+    }
+} catch (Exception $e) {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking: Error getting user services: ' . $e->getMessage());
+    }
+}
+
+// Get user areas
+$user_areas = array();
+try {
+    if (method_exists($geography_manager, 'get_user_areas')) {
+        $user_areas = $geography_manager->get_user_areas($user_id);
+    }
+} catch (Exception $e) {
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking: Error getting user areas: ' . $e->getMessage());
+    }
+}
+
+// Calculate growth percentages (mock data for now)
+$growth_data = array(
+    'bookings_growth' => rand(-15, 25),
+    'revenue_growth' => rand(-10, 30),
+    'customers_growth' => rand(-5, 35)
+);
+
+// Get current time
+$current_time = current_time('timestamp');
+$greeting_hour = date('H', $current_time);
+
+// Determine greeting
+if ($greeting_hour < 12) {
+    $greeting = __('Good morning', 'mobooking');
+} elseif ($greeting_hour < 18) {
+    $greeting = __('Good afternoon', 'mobooking');
+} else {
+    $greeting = __('Good evening', 'mobooking');
+}
+
+// Check if this is their first time
+$is_first_visit = get_user_meta($user_id, 'mobooking_first_visit', true);
+if (!$is_first_visit) {
+    update_user_meta($user_id, 'mobooking_first_visit', current_time('mysql'));
+    $is_first_visit = true;
+} else {
+    $is_first_visit = false;
+}
+?>
+
+<div class="dashboard-overview">
+    <!-- Welcome Section -->
+    <div class="welcome-section">
+        <div class="welcome-content">
+            <div class="welcome-text">
+                <h1 class="welcome-title">
+                    <?php echo $greeting; ?>, <?php echo esc_html($current_user->display_name); ?>!
+                    <span class="wave-emoji">👋</span>
+                </h1>
+                <?php if ($is_first_visit) : ?>
+                    <p class="welcome-subtitle">
+                        <?php _e('Welcome to your MoBooking dashboard! Let\'s get started with setting up your services.', 'mobooking'); ?>
+                    </p>
+                    <div class="quick-setup-actions">
+                        <a href="<?php echo esc_url(add_query_arg('section', 'services')); ?>" class="btn-primary">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M12 5v14M5 12h14"/>
+                            </svg>
+                            <?php _e('Add Your First Service', 'mobooking'); ?>
+                        </a>
+                        <a href="<?php echo esc_url(add_query_arg('section', 'areas')); ?>" class="btn-secondary">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                                <circle cx="12" cy="10" r="3"/>
+                            </svg>
+                            <?php _e('Set Service Areas', 'mobooking'); ?>
+                        </a>
+                    </div>
+                <?php else : ?>
+                    <p class="welcome-subtitle">
+                        <?php _e('Here\'s how your business is performing today.', 'mobooking'); ?>
+                    </p>
+                <?php endif; ?>
+            </div>
+
+            <div class="welcome-visual">
+                <div class="dashboard-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M10 3H3V10H10V3Z"/>
+                        <path d="M21 3H14V10H21V3Z"/>
+                        <path d="M21 14H14V21H21V14Z"/>
+                        <path d="M10 14H3V21H10V14Z"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- KPI Cards Section -->
+    <div class="kpi-section">
+        <div class="kpi-cards-grid">
+            <!-- Total Bookings -->
+            <div class="kpi-card total-bookings" data-kpi="bookings">
+                <div class="kpi-header">
+                    <div class="kpi-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16 2V6M8 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z"/>
+                        </svg>
+                    </div>
+                    <div class="kpi-trend <?php echo $growth_data['bookings_growth'] >= 0 ? 'positive' : 'negative'; ?>">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <?php if ($growth_data['bookings_growth'] >= 0) : ?>
+                                <path d="M7 14l5-5 5 5"/>
+                            <?php else : ?>
+                                <path d="M17 10l-5 5-5-5"/>
+                            <?php endif; ?>
+                        </svg>
+                        <span><?php echo abs($growth_data['bookings_growth']); ?>%</span>
+                    </div>
+                </div>
+                <div class="kpi-content">
+                    <div class="kpi-main-value" data-target="<?php echo $stats['total_bookings']; ?>">
+                        <?php echo $stats['total_bookings']; ?>
+                    </div>
+                    <div class="kpi-label"><?php _e('Total Bookings', 'mobooking'); ?></div>
+                    <div class="kpi-breakdown">
+                        <span class="pending"><?php echo $stats['pending_bookings']; ?> <?php _e('pending', 'mobooking'); ?></span>
+                        <span class="confirmed"><?php echo $stats['confirmed_bookings']; ?> <?php _e('confirmed', 'mobooking'); ?></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Total Revenue -->
+            <div class="kpi-card total-revenue" data-kpi="revenue">
+                <div class="kpi-header">
+                    <div class="kpi-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="12" y1="1" x2="12" y2="23"/>
+                            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+                        </svg>
+                    </div>
+                    <div class="kpi-trend <?php echo $growth_data['revenue_growth'] >= 0 ? 'positive' : 'negative'; ?>">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <?php if ($growth_data['revenue_growth'] >= 0) : ?>
+                                <path d="M7 14l5-5 5 5"/>
+                            <?php else : ?>
+                                <path d="M17 10l-5 5-5-5"/>
+                            <?php endif; ?>
+                        </svg>
+                        <span><?php echo abs($growth_data['revenue_growth']); ?>%</span>
+                    </div>
+                </div>
+                <div class="kpi-content">
+                    <div class="kpi-main-value" data-target="<?php echo $stats['total_revenue']; ?>">
+                        <?php echo function_exists('wc_price') ? wc_price($stats['total_revenue']) : '$' . number_format($stats['total_revenue'], 2); ?>
+                    </div>
+                    <div class="kpi-label"><?php _e('Total Revenue', 'mobooking'); ?></div>
+                    <div class="kpi-breakdown">
+                        <span class="this-month"><?php echo function_exists('wc_price') ? wc_price($stats['this_month_revenue']) : '$' . number_format($stats['this_month_revenue'], 2); ?> <?php _e('this month', 'mobooking'); ?></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- This Month -->
+            <div class="kpi-card this-month" data-kpi="month">
+                <div class="kpi-header">
+                    <div class="kpi-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M8 2V6M16 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z"/>
+                            <path d="M8 14H16M8 18H12"/>
+                        </svg>
+                    </div>
+                    <div class="kpi-period">
+                        <?php echo date_i18n('M Y'); ?>
+                    </div>
+                </div>
+                <div class="kpi-content">
+                    <div class="kpi-main-value" data-target="<?php echo $stats['this_month_revenue']; ?>">
+                        <?php echo function_exists('wc_price') ? wc_price($stats['this_month_revenue']) : '$' . number_format($stats['this_month_revenue'], 2); ?>
+                    </div>
+                    <div class="kpi-label"><?php _e('This Month', 'mobooking'); ?></div>
+                    <div class="kpi-breakdown">
+                        <span class="this-week"><?php echo function_exists('wc_price') ? wc_price($stats['this_week_revenue']) : '$' . number_format($stats['this_week_revenue'], 2); ?> <?php _e('this week', 'mobooking'); ?></span>
+                        <span class="today"><?php echo function_exists('wc_price') ? wc_price($stats['today_revenue']) : '$' . number_format($stats['today_revenue'], 2); ?> <?php _e('today', 'mobooking'); ?></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Completion Rate -->
+            <div class="kpi-card completion-rate" data-kpi="completion">
+                <div class="kpi-header">
+                    <div class="kpi-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                        </svg>
+                    </div>
+                    <div class="kpi-status">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                        </svg>
+                    </div>
+                </div>
+                <div class="kpi-content">
+                    <?php
+                    $completion_rate = $stats['total_bookings'] > 0 ? round(($stats['completed_bookings'] / $stats['total_bookings']) * 100) : 0;
+                    ?>
+                    <div class="kpi-main-value" data-target="<?php echo $completion_rate; ?>">
+                        <?php echo $completion_rate; ?>%
+                    </div>
+                    <div class="kpi-label"><?php _e('Completion Rate', 'mobooking'); ?></div>
+                    <div class="kpi-breakdown">
+                        <span class="completed"><?php echo $stats['completed_bookings']; ?> <?php _e('completed', 'mobooking'); ?></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Main Dashboard Content -->
+    <div class="dashboard-main-content">
+        <div class="content-grid">
+            <!-- Left Column -->
+            <div class="content-left">
+                <!-- Recent Bookings Widget -->
+                <div class="dashboard-widget recent-bookings-widget">
+                    <div class="widget-header">
+                        <h3 class="widget-title">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M16 2V6M8 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z"/>
+                            </svg>
+                            <?php _e('Recent Bookings', 'mobooking'); ?>
+                        </h3>
+                        <a href="<?php echo esc_url(add_query_arg('section', 'bookings')); ?>" class="widget-action">
+                            <?php _e('View All', 'mobooking'); ?>
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M5 12h14M12 5l7 7-7 7"/>
+                            </svg>
+                        </a>
+                    </div>
+
+                    <div class="widget-content">
+                        <?php if (!empty($recent_bookings)) : ?>
+                            <div class="bookings-list">
+                                <?php foreach (array_slice($recent_bookings, 0, 5) as $booking) : ?>
+                                    <div class="booking-item" data-booking-id="<?php echo $booking->id; ?>">
+                                        <div class="booking-customer">
+                                            <div class="customer-avatar">
+                                                <?php echo strtoupper(substr($booking->customer_name, 0, 2)); ?>
+                                            </div>
+                                            <div class="customer-info">
+                                                <div class="customer-name"><?php echo esc_html($booking->customer_name); ?></div>
+                                                <div class="booking-date">
+                                                    <?php echo date_i18n('M j, Y g:i A', strtotime($booking->service_date)); ?>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="booking-details">
+                                            <div class="booking-price">
+                                                <?php echo function_exists('wc_price') ? wc_price($booking->total_price) : '$' . number_format($booking->total_price, 2); ?>
+                                            </div>
+                                            <div class="booking-status">
+                                                <span class="status-badge status-<?php echo esc_attr($booking->status); ?>">
+                                                    <?php
+                                                    switch ($booking->status) {
+                                                        case 'pending':
+                                                            _e('Pending', 'mobooking');
+                                                            break;
+                                                        case 'confirmed':
+                                                            _e('Confirmed', 'mobooking');
+                                                            break;
+                                                        case 'completed':
+                                                            _e('Completed', 'mobooking');
+                                                            break;
+                                                        case 'cancelled':
+                                                            _e('Cancelled', 'mobooking');
+                                                            break;
+                                                    }
+                                                    ?>
+                                                </span>
+                                            </div>
+                                        </div>
+
+                                        <div class="booking-actions">
+                                            <a href="<?php echo esc_url(add_query_arg(array('section' => 'bookings', 'view' => 'single', 'booking_id' => $booking->id))); ?>"
+                                               class="action-btn view-btn" title="<?php _e('View Details', 'mobooking'); ?>">
+                                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                                                    <circle cx="12" cy="12" r="3"/>
+                                                </svg>
+                                            </a>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php else : ?>
+                            <div class="empty-state">
+                                <div class="empty-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                                        <path d="M16 2V6M8 2V6M3 10H21M5 4H19C20.1046 4 21 4.89543 21 6V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V6C3 4.89543 3.89543 4 5 4Z"/>
+                                    </svg>
+                                </div>
+                                <h4><?php _e('No bookings yet', 'mobooking'); ?></h4>
+                                <p><?php _e('Your recent bookings will appear here once customers start booking your services.', 'mobooking'); ?></p>
+                                <a href="<?php echo esc_url(add_query_arg('section', 'booking-form')); ?>" class="btn-primary">
+                                    <?php _e('Share Your Booking Link', 'mobooking'); ?>
+                                </a>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <!-- Quick Actions Widget -->
+                <div class="dashboard-widget quick-actions-widget">
+                    <div class="widget-header">
+                        <h3 class="widget-title">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="3"/>
+                                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+                            </svg>
+                            <?php _e('Quick Actions', 'mobooking'); ?>
+                        </h3>
+                    </div>
+
+                    <div class="widget-content">
+                        <div class="quick-actions-grid">
+                            <a href="<?php echo esc_url(add_query_arg('section', 'services')); ?>" class="quick-action">
+                                <div class="action-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M12 5v14M5 12h14"/>
+                                    </svg>
+                                </div>
+                                <div class="action-content">
+                                    <div class="action-title"><?php _e('Add Service', 'mobooking'); ?></div>
+                                    <div class="action-desc"><?php _e('Create new service', 'mobooking'); ?></div>
+                                </div>
+                            </a>
+
+                            <a href="<?php echo esc_url(add_query_arg('section', 'discounts')); ?>" class="quick-action">
+                                <div class="action-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                                    </svg>
+                                </div>
+                                <div class="action-content">
+                                    <div class="action-title"><?php _e('Create Discount', 'mobooking'); ?></div>
+                                    <div class="action-desc"><?php _e('Add promo codes', 'mobooking'); ?></div>
+                                </div>
+                            </a>
+
+                            <a href="<?php echo esc_url(add_query_arg('section', 'areas')); ?>" class="quick-action">
+                                <div class="action-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                                        <circle cx="12" cy="10" r="3"/>
+                                    </svg>
+                                </div>
+                                <div class="action-content">
+                                    <div class="action-title"><?php _e('Service Areas', 'mobooking'); ?></div>
+                                    <div class="action-desc"><?php _e('Manage coverage', 'mobooking'); ?></div>
+                                </div>
+                            </a>
+
+                            <a href="<?php echo esc_url(add_query_arg('section', 'settings')); ?>" class="quick-action">
+                                <div class="action-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="12" cy="12" r="3"/>
+                                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+                                    </svg>
+                                </div>
+                                <div class="action-content">
+                                    <div class="action-title"><?php _e('Settings', 'mobooking'); ?></div>
+                                    <div class="action-desc"><?php _e('Configure options', 'mobooking'); ?></div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right Column -->
+            <div class="content-right">
+                <!-- Popular Service Widget -->
+                <?php if ($stats['most_popular_service']) : ?>
+                    <div class="dashboard-widget popular-service-widget">
+                        <div class="widget-header">
+                            <h3 class="widget-title">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                                </svg>
+                                <?php _e('Most Popular Service', 'mobooking'); ?>
+                            </h3>
+                        </div>
+
+                        <div class="widget-content">
+                            <div class="popular-service-card">
+                                <div class="service-header">
+                                    <div class="service-icon">
+                                        <?php if (!empty($stats['most_popular_service']->icon)) : ?>
+                                            <i class="<?php echo esc_attr($stats['most_popular_service']->icon); ?>"></i>
+                                        <?php else : ?>
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <path d="M16.5 9.40002L7.5 4.21002M3.27 6.96002L12 12.01L20.73 6.96002M12 22.08V12"/>
+                                            </svg>
+                                        <?php endif; ?>
+                                    </div>
+                                    <div class="service-badge">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                                        </svg>
+                                        <?php _e('Popular', 'mobooking'); ?>
+                                    </div>
+                                </div>
+
+                                <div class="service-info">
+                                    <h4 class="service-name"><?php echo esc_html($stats['most_popular_service']->name); ?></h4>
+                                    <?php if (!empty($stats['most_popular_service']->description)) : ?>
+                                        <p class="service-description"><?php echo esc_html(wp_trim_words($stats['most_popular_service']->description, 15)); ?></p>
+                                    <?php endif; ?>
+
+                                    <div class="service-stats">
+                                        <div class="stat-item">
+<span class="stat-value">$<?php echo number_format($stats['most_popular_service']->price, 2); ?></span>                                            <span class="stat-label"><?php _e('Price', 'mobooking'); ?></span>
+                                        </div>
+                                        <div class="stat-item">
+                                            <span class="stat-value"><?php echo $stats['most_popular_service']->duration; ?> <?php _e('min', 'mobooking'); ?></span>
+                                            <span class="stat-label"><?php _e('Duration', 'mobooking'); ?></span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="service-actions">
+                                    <a href="<?php echo esc_url(add_query_arg(array('section' => 'services', 'view' => 'edit', 'service_id' => $stats['most_popular_service']->id))); ?>" class="btn-secondary">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                                            <path d="m18.5 2.5-9.5 9.5L4 15l1-4 9.5-9.5 3 3Z"/>
+                                        </svg>
+                                        <?php _e('Edit Service', 'mobooking'); ?>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                <?php endif; ?>
+
+                <!-- Business Setup Widget -->
+                <div class="dashboard-widget setup-widget">
+                    <div class="widget-header">
+                        <h3 class="widget-title">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M9 12l2 2 4-4M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"/>
+                            </svg>
+                            <?php _e('Setup Progress', 'mobooking'); ?>
+                        </h3>
+                    </div>
+
+                    <div class="widget-content">
+                        <?php
+                        // Calculate setup progress
+                        $setup_steps = array(
+                            'services' => !empty($user_services),
+                            'areas' => !empty($user_areas),
+                            'settings' => !empty($settings->company_name),
+                            'branding' => !empty($settings->logo_url) || !empty($settings->primary_color)
+                        );
+
+                        $completed_steps = count(array_filter($setup_steps));
+                        $total_steps = count($setup_steps);
+                        $progress_percentage = ($completed_steps / $total_steps) * 100;
+                        ?>
+
+                        <div class="setup-progress">
+                            <div class="progress-header">
+                                <span class="progress-text"><?php echo $completed_steps; ?> <?php _e('of', 'mobooking'); ?> <?php echo $total_steps; ?> <?php _e('completed', 'mobooking'); ?></span>
+                                <span class="progress-percentage"><?php echo round($progress_percentage); ?>%</span>
+                            </div>
+
+                            <div class="progress-bar">
+                                <div class="progress-fill" style="width: <?php echo $progress_percentage; ?>%"></div>
+                            </div>
+                        </div>
+
+                        <div class="setup-checklist">
+                            <div class="checklist-item <?php echo $setup_steps['services'] ? 'completed' : 'pending'; ?>">
+                                <div class="item-status">
+                                    <?php if ($setup_steps['services']) : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M20 6L9 17l-5-5"/>
+                                        </svg>
+                                    <?php else : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <circle cx="12" cy="12" r="10"/>
+                                        </svg>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="item-content">
+                                    <div class="item-title"><?php _e('Add Services', 'mobooking'); ?></div>
+                                    <div class="item-description"><?php _e('Create your first service offering', 'mobooking'); ?></div>
+                                </div>
+                                <?php if (!$setup_steps['services']) : ?>
+                                    <a href="<?php echo esc_url(add_query_arg('section', 'services')); ?>" class="item-action">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M5 12h14M12 5l7 7-7 7"/>
+                                        </svg>
+                                    </a>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="checklist-item <?php echo $setup_steps['areas'] ? 'completed' : 'pending'; ?>">
+                                <div class="item-status">
+                                    <?php if ($setup_steps['areas']) : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M20 6L9 17l-5-5"/>
+                                        </svg>
+                                    <?php else : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <circle cx="12" cy="12" r="10"/>
+                                        </svg>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="item-content">
+                                    <div class="item-title"><?php _e('Set Service Areas', 'mobooking'); ?></div>
+                                    <div class="item-description"><?php _e('Define where you provide services', 'mobooking'); ?></div>
+                                </div>
+                                <?php if (!$setup_steps['areas']) : ?>
+                                    <a href="<?php echo esc_url(add_query_arg('section', 'areas')); ?>" class="item-action">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M5 12h14M12 5l7 7-7 7"/>
+                                        </svg>
+                                    </a>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="checklist-item <?php echo $setup_steps['settings'] ? 'completed' : 'pending'; ?>">
+                                <div class="item-status">
+                                    <?php if ($setup_steps['settings']) : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M20 6L9 17l-5-5"/>
+                                        </svg>
+                                    <?php else : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <circle cx="12" cy="12" r="10"/>
+                                        </svg>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="item-content">
+                                    <div class="item-title"><?php _e('Business Info', 'mobooking'); ?></div>
+                                    <div class="item-description"><?php _e('Add your company details', 'mobooking'); ?></div>
+                                </div>
+                                <?php if (!$setup_steps['settings']) : ?>
+                                    <a href="<?php echo esc_url(add_query_arg('section', 'settings')); ?>" class="item-action">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M5 12h14M12 5l7 7-7 7"/>
+                                        </svg>
+                                    </a>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="checklist-item <?php echo $setup_steps['branding'] ? 'completed' : 'pending'; ?>">
+                                <div class="item-status">
+                                    <?php if ($setup_steps['branding']) : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M20 6L9 17l-5-5"/>
+                                        </svg>
+                                    <?php else : ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <circle cx="12" cy="12" r="10"/>
+                                        </svg>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="item-content">
+                                    <div class="item-title"><?php _e('Customize Branding', 'mobooking'); ?></div>
+                                    <div class="item-description"><?php _e('Add logo and brand colors', 'mobooking'); ?></div>
+                                </div>
+                                <?php if (!$setup_steps['branding']) : ?>
+                                    <a href="<?php echo esc_url(add_query_arg('section', 'settings')); ?>" class="item-action">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M5 12h14M12 5l7 7-7 7"/>
+                                        </svg>
+                                    </a>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <?php if ($progress_percentage == 100) : ?>
+                            <div class="setup-complete">
+                                <div class="complete-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                                    </svg>
+                                </div>
+                                <div class="complete-text">
+                                    <h4><?php _e('Setup Complete!', 'mobooking'); ?></h4>
+                                    <p><?php _e('Your business is ready to accept bookings.', 'mobooking'); ?></p>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <!-- Tips & Resources Widget -->
+                <div class="dashboard-widget tips-widget">
+                    <div class="widget-header">
+                        <h3 class="widget-title">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="10"/>
+                                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
+                                <path d="M12 17h.01"/>
+                            </svg>
+                            <?php _e('Tips & Resources', 'mobooking'); ?>
+                        </h3>
+                    </div>
+
+                    <div class="widget-content">
+                        <div class="tips-list">
+                            <div class="tip-item">
+                                <div class="tip-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M9 11H5a2 2 0 0 0-2 2v3c0 1.1.9 2 2 2h4m6-6h4a2 2 0 0 1 2 2v3c0 1.1-.9 2-2 2h-4m-6 0a2 2 0 0 0-2-2v-3c0-1.1.9-2 2-2m0 0V6a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v3"/>
+                                    </svg>
+                                </div>
+                                <div class="tip-content">
+                                    <h5><?php _e('Share Your Booking Link', 'mobooking'); ?></h5>
+                                    <p><?php _e('Add your booking form link to your website and social media profiles to start receiving bookings.', 'mobooking'); ?></p>
+                                    <a href="<?php echo esc_url(add_query_arg('section', 'booking-form')); ?>" class="tip-action">
+                                        <?php _e('Get Link', 'mobooking'); ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M5 12h14M12 5l7 7-7 7"/>
+                                        </svg>
+                                    </a>
+                                </div>
+                            </div>
+
+                            <div class="tip-item">
+                                <div class="tip-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                                    </svg>
+                                </div>
+                                <div class="tip-content">
+                                    <h5><?php _e('Create Promotional Codes', 'mobooking'); ?></h5>
+                                    <p><?php _e('Attract new customers with discount codes and special offers for your services.', 'mobooking'); ?></p>
+                                    <a href="<?php echo esc_url(add_query_arg('section', 'discounts')); ?>" class="tip-action">
+                                        <?php _e('Create Discount', 'mobooking'); ?>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M5 12h14M12 5l7 7-7 7"/>
+                                        </svg>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+jQuery(document).ready(function($) {
+    'use strict';
+
+    console.log('📊 Dashboard Overview initializing...');
+
+    // Animate counters on page load
+    // function animateCounters() {
+    //     $('.kpi-main-value').each(function() {
+    //         const $this = $(this);
+    //         const text = $this.text();
+    //         const isPrice = text.includes(');
+    //         const number = parseFloat(text.replace(/[^0-9.]/g, ''));
+
+    //         if (!isNaN(number) && number > 0) {
+    //             $this.prop('Counter', 0).animate({
+    //                 Counter: number
+    //             }, {
+    //                 duration: 2000,
+    //                 easing: 'easeOutCubic',
+    //                 step: function (now) {
+    //                     if (isPrice) {
+    //                         $this.text(' + Math.ceil(now).toLocaleString());
+    //                     } else {
+    //                         $this.text(Math.ceil(now).toLocaleString());
+    //                     }
+    //                 },
+    //                 complete: function() {
+    //                     if (isPrice) {
+    //                         $this.text(text); // Restore original formatting
+    //                     } else {
+    //                         $this.text(number.toLocaleString());
+    //                     }
+    //                 }
+    //             });
+    //         }
+    //     });
+    // }
+
+    // Animate progress bars
+    function animateProgressBars() {
+        $('.progress-fill').each(function() {
+            const $this = $(this);
+            const width = $this.data('width') || $this.css('width');
+            $this.css('width', '0%').animate({
+                width: width
+            }, 1500, 'easeOutCubic');
+        });
+    }
+
+    // Add loading states to quick actions
+    $('.quick-action').on('click', function() {
+        $(this).addClass('loading');
+    });
+
+
+    // Initialize animations with delay for better UX
+    setTimeout(() => {
+        // animateCounters();
+        animateProgressBars();
+    }, 500);
+
+    // Refresh stats periodically (every 5 minutes)
+    setInterval(function() {
+        refreshDashboardStats();
+    }, 300000);
+
+    function refreshDashboardStats() {
+        $.ajax({
+            url: mobookingDashboard.ajaxUrl,
+            type: 'POST',
+            data: {
+                action: 'mobooking_get_dashboard_stats',
+                nonce: mobookingDashboard.nonces.service
+            },
+            success: function(response) {
+                if (response.success && response.data.stats) {
+                    updateStats(response.data.stats);
+                }
+            },
+            error: function() {
+                console.log('Failed to refresh dashboard stats');
+            }
+        });
+    }
+
+    function updateStats(stats) {
+        // Update KPI values with animation
+        Object.keys(stats).forEach(key => {
+            const $element = $(`[data-kpi="${key}"] .kpi-main-value`);
+            if ($element.length) {
+                const newValue = stats[key];
+                const currentValue = parseFloat($element.text().replace(/[^0-9.]/g, ''));
+
+                if (newValue !== currentValue) {
+                    $element.addClass('updating');
+                    setTimeout(() => {
+                        $element.text(newValue).removeClass('updating');
+                    }, 300);
+                }
+            }
+        });
+    }
+
+    // Add click-to-copy functionality for stats
+    $('.kpi-main-value').on('click', function() {
+        const text = $(this).text();
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(text).then(() => {
+                showNotification('Copied to clipboard!', 'success');
+            });
+        }
+    });
+
+    // Show notification function
+    function showNotification(message, type = 'info') {
+        const notification = $(`
+            <div class="dashboard-notification ${type}">
+                <span>${message}</span>
+            </div>
+        `);
+
+        $('body').append(notification);
+
+        setTimeout(() => {
+            notification.addClass('show');
+        }, 100);
+
+        setTimeout(() => {
+            notification.removeClass('show');
+            setTimeout(() => notification.remove(), 300);
+        }, 3000);
+    }
+
+    // Add keyboard shortcuts
+    $(document).on('keydown', function(e) {
+        if (e.ctrlKey || e.metaKey) {
+            switch(e.which) {
+                case 83: // Ctrl+S - Go to Services
+                    e.preventDefault();
+                    window.location.href = '<?php echo esc_js(add_query_arg('section', 'services')); ?>';
+                    break;
+                case 66: // Ctrl+B - Go to Bookings
+                    e.preventDefault();
+                    window.location.href = '<?php echo esc_js(add_query_arg('section', 'bookings')); ?>';
+                    break;
+                case 68: // Ctrl+D - Go to Discounts
+                    e.preventDefault();
+                    window.location.href = '<?php echo esc_js(add_query_arg('section', 'discounts')); ?>';
+                    break;
+            }
+        }
+    });
+
+    // Performance monitoring
+    const perfStart = performance.now();
+    $(window).on('load', function() {
+        const loadTime = performance.now() - perfStart;
+        console.log(`📊 Dashboard loaded in ${Math.round(loadTime)}ms`);
+    });
+
+    console.log('✅ Dashboard Overview ready');
+});
+</script>
+
+<?php
+// Enqueue additional scripts for overview functionality
+wp_enqueue_script('jquery-ui-core');
+wp_enqueue_script('jquery-effects-core');
+
+// Add custom easing
+wp_add_inline_script('mobooking-dashboard', '
+jQuery.easing.easeOutCubic = function (x, t, b, c, d) {
+    return c*((t=t/d-1)*t*t + 1) + b;
+};
+');
+?>

--- a/page-services.php
+++ b/page-services.php
@@ -1,0 +1,2753 @@
+<?php
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Get current view and service ID
+$current_view = isset($_GET['view']) ? sanitize_text_field($_GET['view']) : 'list';
+$service_id = isset($_GET['service_id']) ? absint($_GET['service_id']) : 0;
+$active_tab = isset($_GET['active_tab']) ? sanitize_text_field($_GET['active_tab']) : 'basic-info';
+
+// Initialize managers
+$service_manager = new \MoBooking\Services\ServicesManager();
+$options_manager = new \MoBooking\Services\ServiceOptionsManager();
+
+// Handle service editing
+$service_data = null;
+if ($current_view === 'edit' && $service_id) {
+    $service_data = $service_manager->get_service($service_id, $user_id);
+    if (!$service_data) {
+        $current_view = 'list';
+    }
+}
+
+// Get user's services for list view
+$services = array();
+$categories = array();
+if ($current_view === 'list') {
+    $services = $service_manager->get_user_services($user_id);
+    $categories = $service_manager->get_user_categories($user_id);
+}
+
+// Available icons for services
+$available_icons = array(
+    'dashicons-admin-home' => 'Home',
+    'dashicons-building' => 'Building',
+    'dashicons-admin-tools' => 'Tools',
+    'dashicons-hammer' => 'Hammer',
+    'dashicons-admin-appearance' => 'Brush',
+    'dashicons-car' => 'Car',
+    'dashicons-products' => 'Products',
+    'dashicons-money-alt' => 'Money',
+    'dashicons-chart-line' => 'Chart',
+    'dashicons-calendar-alt' => 'Calendar',
+    'dashicons-clock' => 'Clock',
+    'dashicons-location-alt' => 'Location',
+    'dashicons-email-alt' => 'Email',
+    'dashicons-phone' => 'Phone',
+    'dashicons-star-filled' => 'Star',
+    'dashicons-heart' => 'Heart',
+    'dashicons-shield' => 'Shield',
+    'dashicons-lightbulb' => 'Lightbulb',
+    'dashicons-tag' => 'Tag'
+);
+?>
+
+<div class="services-section modern-compact">
+    <?php if ($current_view === 'list') : ?>
+        <!-- ===== MODERN SERVICES LIST VIEW ===== -->
+        <div class="services-header-modern">
+            <div class="header-main">
+                <div class="title-section">
+                    <h1 class="page-title">
+                        <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16.5 9.40002L7.5 4.21002M3.27 6.96002L12 12.01L20.73 6.96002M12 22.08V12M21 16V8.00002C20.9996 7.6493 20.9071 7.00119 20.556 6.69754 20.3037 6.44539 20 6.27002L13 2.27002C12.696 2.09449 12.3511 2.00208 12 2.00208C11.6489 2.00208 11.304 2.09449 11 2.27002L4 6.27002C3.69626 6.44539 3.44398 6.69754 3.26846 7.00119C3.09294 7.30483 3.00036 7.6493 3 8.00002V16C3.00036 16.3508 3.09294 16.6952 3.26846 16.9989C3.44398 17.3025 3.69626 17.5547 4 17.73L11 21.73C11.304 21.9056 11.6489 21.998 12 21.998C12.3511 21.998 12.696 21.9056 13 21.73L20 17.73C20.3037 17.5547 20.556 17.3025 20.7315 16.9989C20.9071 16.6952 20.9996 16.3508 21 16Z"/>
+                        </svg>
+                        Services
+                    </h1>
+                    <p class="page-subtitle">Manage your service offerings</p>
+                </div>
+
+                <?php if (!empty($services)) : ?>
+                    <div class="quick-stats">
+                        <div class="stat-pill">
+                            <span class="stat-number"><?php echo count($services); ?></span>
+                            <span class="stat-label">Total</span>
+                        </div>
+                        <div class="stat-pill active">
+                            <span class="stat-number"><?php echo count(array_filter($services, function($s) { return $s->status === 'active'; })); ?></span>
+                            <span class="stat-label">Active</span>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <div class="header-actions">
+                <?php if (!empty($services)) : ?>
+                    <div class="filter-compact">
+                        <select id="category-filter" class="filter-select-modern">
+                            <option value="">All Categories</option>
+                            <?php foreach ($categories as $category) : ?>
+                                <option value="<?php echo esc_attr($category); ?>"><?php echo esc_html(ucfirst($category)); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                <?php endif; ?>
+
+                <a href="<?php echo esc_url(add_query_arg(array('view' => 'new'), home_url('/dashboard/services/'))); ?>" class="btn-add-modern">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 5v14M5 12h14"/>
+                    </svg>
+                    Add Service
+                </a>
+            </div>
+        </div>
+
+        <?php if (empty($services)) : ?>
+            <!-- Modern Empty State -->
+            <div class="empty-state-modern">
+                <div class="empty-visual">
+                    <div class="empty-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+                        </svg>
+                    </div>
+                </div>
+                <div class="empty-content">
+                    <h3>Create Your First Service</h3>
+                    <p>Start building your service catalog with detailed descriptions, pricing, and customizable options.</p>
+                    <a href="<?php echo esc_url(add_query_arg(array('view' => 'new'), home_url('/dashboard/services/'))); ?>" class="btn-create-first">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 5v14M5 12h14"/>
+                        </svg>
+                        Create First Service
+                    </a>
+                </div>
+            </div>
+        <?php else : ?>
+            <!-- Modern Services Grid -->
+            <div class="services-grid-modern">
+                <?php foreach ($services as $service) :
+                    $options_count = count($options_manager->get_service_options($service->id));
+                ?>
+                    <div class="service-card-modern" data-category="<?php echo esc_attr($service->category); ?>">
+                        <div class="card-header">
+                            <div class="service-visual">
+                                <?php if (!empty($service->image_url)) : ?>
+                                    <div class="service-image">
+                                        <img src="<?php echo esc_url($service->image_url); ?>" alt="<?php echo esc_attr($service->name); ?>">
+                                    </div>
+                                <?php elseif (!empty($service->icon)) : ?>
+                                    <div class="service-icon">
+                                        <span class="dashicons <?php echo esc_attr($service->icon); ?>"></span>
+                                    </div>
+                                <?php else : ?>
+                                    <div class="service-icon default">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+                                        </svg>
+                                    </div>
+                                <?php endif; ?>
+
+                                <div class="status-indicator <?php echo esc_attr($service->status); ?>">
+                                    <?php if ($service->status === 'active') : ?>
+                                        <div class="status-dot active"></div>
+                                    <?php else : ?>
+                                        <div class="status-dot inactive"></div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+
+                            <div class="card-actions">
+                                <button type="button" class="action-btn edit" data-id="<?php echo esc_attr($service->id); ?>" title="Edit Service">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                        <path d="m18.5 2.5 3 3L12 15l-4 1 1-4 9.5-9.5Z"></path>
+                                    </svg>
+                                </button>
+                                <button type="button" class="action-btn delete delete-service-btn" data-id="<?php echo esc_attr($service->id); ?>" title="Delete Service">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="m3 6 3 18h12l3-18"></path>
+                                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="card-content">
+                            <div class="service-title">
+                                <h3><?php echo esc_html($service->name); ?></h3>
+                                <?php if (!empty($service->category)) : ?>
+                                    <span class="category-tag <?php echo esc_attr($service->category); ?>">
+                                        <?php echo esc_html(ucfirst($service->category)); ?>
+                                    </span>
+                                <?php endif; ?>
+                            </div>
+
+                            <?php if (!empty($service->description)) : ?>
+                                <p class="service-description">
+                                    <?php echo wp_trim_words(esc_html($service->description), 15); ?>
+                                </p>
+                            <?php endif; ?>
+
+                            <div class="service-meta">
+                                <div class="meta-item price">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <line x1="12" y1="1" x2="12" y2="23"></line>
+                                        <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                    </svg>
+                                    <span><?php echo wc_price($service->price); ?></span>
+                                </div>
+
+                                <div class="meta-item duration">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="12" cy="12" r="10"></circle>
+                                        <polyline points="12,6 12,12 16,14"></polyline>
+                                    </svg>
+                                    <span><?php echo sprintf(_n('%d min', '%d mins', $service->duration, 'mobooking'), $service->duration); ?></span>
+                                </div>
+
+                                <?php if ($options_count > 0) : ?>
+                                    <div class="meta-item options">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <circle cx="12" cy="12" r="3"/>
+                                            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+                                        </svg>
+                                        <span><?php echo $options_count; ?></span>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <div class="card-footer">
+                            <a href="<?php echo esc_url(add_query_arg(array('view' => 'edit', 'service_id' => $service->id), home_url('/dashboard/services/'))); ?>"
+                               class="btn-edit-modern">
+                                Edit Service
+                            </a>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
+    <?php else : ?>
+        <!-- ===== MODERN SERVICE FORM VIEW ===== -->
+        <div class="service-form-modern">
+            <!-- Compact Breadcrumb -->
+            <div class="breadcrumb-modern">
+                <a href="<?php echo esc_url(home_url('/dashboard/services/')); ?>" class="breadcrumb-link">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M16.5 9.40002L7.5 4.21002M3.27 6.96002L12 12.01L20.73 6.96002M12 22.08V12"/>
+                    </svg>
+                    Services
+                </a>
+                <svg class="breadcrumb-separator" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="m9 18 6-6-6-6"/>
+                </svg>
+                <span class="breadcrumb-current">
+                    <?php echo $current_view === 'edit' ? __('Edit Service', 'mobooking') : __('New Service', 'mobooking'); ?>
+                </span>
+            </div>
+
+            <!-- Compact Header -->
+            <div class="form-header-modern">
+                <div class="header-content">
+                    <h1 class="form-title-modern">
+                        <?php if ($current_view === 'edit') : ?>
+                            <?php echo esc_html($service_data->name); ?>
+                        <?php else : ?>
+                            <?php _e('New Service', 'mobooking'); ?>
+                        <?php endif; ?>
+                    </h1>
+                    <?php if ($current_view === 'edit') : ?>
+                        <div class="service-status-badge <?php echo esc_attr($service_data->status); ?>">
+                            <?php echo esc_html(ucfirst($service_data->status)); ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+                <a href="<?php echo esc_url(home_url('/dashboard/services/')); ?>" class="btn-back-modern">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="m12 19-7-7 7-7M19 12H5"/>
+                    </svg>
+                    Back
+                </a>
+            </div>
+
+            <!-- Compact Tabs -->
+            <div class="tabs-modern">
+                <div class="tab-nav">
+                    <button type="button" class="tab-btn <?php echo $active_tab === 'basic-info' ? 'active' : ''; ?>"
+                            data-tab="basic-info">
+                        <span class="tab-title">Details</span>
+                    </button>
+                    <button type="button" class="tab-btn <?php echo $active_tab === 'presentation' ? 'active' : ''; ?>"
+                            data-tab="presentation">
+                        <span class="tab-title">Appearance</span>
+                    </button>
+                    <button type="button" class="tab-btn <?php echo $active_tab === 'options' ? 'active' : ''; ?>"
+                            data-tab="options">
+                        <span class="tab-title">Options</span>
+                        <?php if ($service_id) : ?>
+                            <?php
+                            $options_count = count($options_manager->get_service_options($service_id));
+                            if ($options_count > 0) : ?>
+                                <span class="tab-badge"><?php echo $options_count; ?></span>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </button>
+                </div>
+            </div>
+
+            <!-- Service Form -->
+            <form id="service-form" method="post" class="service-form-compact">
+                <input type="hidden" id="service-id" name="id" value="<?php echo $service_data ? esc_attr($service_data->id) : ''; ?>">
+                <?php wp_nonce_field('mobooking-service-nonce', 'nonce'); ?>
+                <?php wp_nonce_field('mobooking-image-upload-nonce', 'image_upload_nonce_field'); ?>
+
+                <!-- Basic Info Tab -->
+                <div id="basic-info" class="tab-content <?php echo $active_tab === 'basic-info' ? 'active' : ''; ?>">
+                    <div class="form-section-compact">
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="service-name" class="field-label">Service Name <span class="required">*</span></label>
+                                <input type="text" id="service-name" name="name" class="form-input"
+                                       value="<?php echo $service_data ? esc_attr($service_data->name) : ''; ?>"
+                                       placeholder="e.g., Deep House Cleaning" required>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="service-category" class="field-label">Category</label>
+                                <select id="service-category" name="category" class="form-input">
+                                    <option value="">Select Category</option>
+                                    <option value="residential" <?php selected($service_data ? $service_data->category : '', 'residential'); ?>>Residential</option>
+                                    <option value="commercial" <?php selected($service_data ? $service_data->category : '', 'commercial'); ?>>Commercial</option>
+                                    <option value="special" <?php selected($service_data ? $service_data->category : '', 'special'); ?>>Special</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="service-price" class="field-label">Price <span class="required">*</span></label>
+                                <div class="input-with-icon">
+                                    <svg class="input-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <line x1="12" y1="1" x2="12" y2="23"></line>
+                                        <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                    </svg>
+                                    <input type="number" id="service-price" name="price" class="form-input"
+                                           value="<?php echo $service_data ? esc_attr($service_data->price) : ''; ?>"
+                                           step="0.01" min="0" placeholder="0.00" required>
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="service-duration" class="field-label">Duration <span class="required">*</span></label>
+                                <div class="input-with-suffix">
+                                    <input type="number" id="service-duration" name="duration" class="form-input"
+                                           value="<?php echo $service_data ? esc_attr($service_data->duration) : '60'; ?>"
+                                           min="15" step="15" placeholder="60" required>
+                                    <span class="input-suffix">min</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="service-description" class="field-label">Description</label>
+                            <textarea id="service-description" name="description" class="form-input" rows="3"
+                                      placeholder="Describe what this service includes..."><?php echo $service_data ? esc_textarea($service_data->description) : ''; ?></textarea>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="service-status" class="field-label">Status</label>
+                            <select id="service-status" name="status" class="form-input">
+                                <option value="active" <?php selected($service_data ? $service_data->status : 'active', 'active'); ?>>Active</option>
+                                <option value="inactive" <?php selected($service_data ? $service_data->status : '', 'inactive'); ?>>Inactive</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Appearance Tab -->
+                <div id="presentation" class="tab-content <?php echo $active_tab === 'presentation' ? 'active' : ''; ?>">
+                    <div class="form-section-compact">
+                        <div class="appearance-grid">
+                            <div class="icon-section">
+                                <label class="field-label">Service Icon</label>
+                                <input type="hidden" id="service-icon" name="icon" value="<?php echo $service_data ? esc_attr($service_data->icon) : ''; ?>">
+
+                                <div class="icon-picker">
+                                    <div class="current-icon">
+                                        <?php if ($service_data && !empty($service_data->icon)) : ?>
+                                            <span class="dashicons <?php echo esc_attr($service_data->icon); ?>"></span>
+                                        <?php else : ?>
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+                                            </svg>
+                                        <?php endif; ?>
+                                    </div>
+
+                                    <div class="icon-grid">
+                                        <?php foreach ($available_icons as $icon_class => $icon_name) : ?>
+                                            <div class="icon-option <?php echo ($service_data && $service_data->icon === $icon_class) ? 'selected' : ''; ?>"
+                                                 data-icon="<?php echo esc_attr($icon_class); ?>" title="<?php echo esc_attr($icon_name); ?>">
+                                                <span class="dashicons <?php echo esc_attr($icon_class); ?>"></span>
+                                            </div>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="image-section">
+                                <label for="service-image-upload" class="field-label">Custom Image</label>
+                                <div class="image-upload-compact">
+                                    <div class="image-preview">
+                                        <?php if ($service_data && !empty($service_data->image_url)) : ?>
+                                            <img src="<?php echo esc_url($service_data->image_url); ?>" alt="Service image">
+                                        <?php else : ?>
+                                            <div class="image-placeholder">
+                                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
+                                                    <circle cx="9" cy="9" r="2"/>
+                                                    <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
+                                                </svg>
+                                                <span>No image</span>
+                                            </div>
+                                        <?php endif; ?>
+                                    </div>
+
+                                    <div class="image-controls">
+                                        <input type="file" id="service-image-upload" name="service_image_upload" accept="image/*" style="display: none;">
+                                        <button type="button" id="btn-select-image-upload" class="btn-select-image">Select Image</button>
+                                        <button type="button" id="btn-replace-image" class="btn-replace-image" style="display: none;">Replace</button>
+                                        <button type="button" id="btn-delete-image" class="btn-delete-image" style="display: none;">Delete</button>
+                                        <input type="hidden" id="service-image-url" name="image_url" value="<?php echo $service_data ? esc_attr($service_data->image_url) : ''; ?>">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Options Tab -->
+                <div id="options" class="tab-content <?php echo $active_tab === 'options' ? 'active' : ''; ?>">
+                    <div class="form-section-compact">
+                        <div class="options-header-compact">
+                            <div>
+                                <h3>Service Options</h3>
+                                <p>Add customizable options for this service</p>
+                            </div>
+                            <button type="button" id="add-option-btn" class="btn-add-option"
+                                    <?php echo !$service_id ? 'disabled title="Save the service first"' : ''; ?>>
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 5v14M5 12h14"/>
+                                </svg>
+                                Add Option
+                            </button>
+                        </div>
+
+                        <div id="service-options-container" class="options-container-compact">
+                            <!-- Options will be loaded via JavaScript -->
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Fixed Footer Actions -->
+                <div class="form-footer-modern">
+                    <div class="footer-left">
+                        <?php if ($current_view === 'edit') : ?>
+                            <button type="button" class="btn-delete delete-service-btn" data-id="<?php echo esc_attr($service_data->id); ?>">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="m3 6 3 18h12l3-18"></path>
+                                    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
+                                </svg>
+                                Delete
+                            </button>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="footer-right">
+                        <button type="submit" id="save-service-button" class="btn-save-modern">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M17 21V13H7V21M7 3V8H15M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z"/>
+                            </svg>
+                            <span class="btn-text">
+                                <?php echo $current_view === 'edit' ? __('Save Changes', 'mobooking') : __('Create Service', 'mobooking'); ?>
+                            </span>
+                            <span class="btn-loading" style="display: none;">
+                                <div class="spinner-modern"></div>
+                                Saving...
+                            </span>
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    <?php endif; ?>
+</div>
+
+<!-- Modals (Keep existing modals but with modern styling) -->
+<!-- Option Modal -->
+<div id="option-modal" class="modal-modern" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="option-modal-title">
+    <div class="modal-content-modern">
+        <div class="modal-header-modern">
+            <h3 id="option-modal-title">Add New Option</h3>
+            <button type="button" class="modal-close-modern" aria-label="Close">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 6 6 18M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+
+        <div class="modal-body-modern">
+            <form id="option-form" method="post">
+                <input type="hidden" id="option-id" name="id">
+                <input type="hidden" id="option-service-id" name="service_id" value="<?php echo esc_attr($service_id); ?>">
+                <?php wp_nonce_field('mobooking-service-nonce', 'nonce'); ?>
+
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label for="option-name">Option Name <span class="required">*</span></label>
+                        <input type="text" id="option-name" name="name" class="form-input"
+                               placeholder="e.g., Extra cleaning supplies" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="option-type">Option Type</label>
+                        <select id="option-type" name="type" class="form-input">
+                            <option value="checkbox">Checkbox</option>
+                            <option value="text">Text Input</option>
+                            <option value="number">Number Input</option>
+                            <option value="select">Dropdown Select</option>
+                            <option value="radio">Radio Buttons</option>
+                            <option value="textarea">Text Area</option>
+                            <option value="quantity">Quantity Selector</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="option-description">Description</label>
+                    <textarea id="option-description" name="description" class="form-input" rows="2"
+                              placeholder="Optional description to help customers understand this option"></textarea>
+                </div>
+
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label for="option-required">Required</label>
+                        <select id="option-required" name="is_required" class="form-input">
+                            <option value="0">Optional</option>
+                            <option value="1">Required</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="option-price-type">Price Impact</label>
+                        <select id="option-price-type" name="price_type" class="form-input">
+                            <option value="none">No Price Impact</option>
+                            <option value="fixed">Fixed Amount</option>
+                            <option value="percentage">Percentage</option>
+                            <option value="multiply">Multiply by Value</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div id="price-impact-group" class="form-group">
+                    <label for="option-price-impact">Price Impact Amount</label>
+                    <input type="number" id="option-price-impact" name="price_impact" class="form-input"
+                           step="0.01" value="0" placeholder="0.00">
+                </div>
+
+                <!-- Dynamic fields will be inserted here -->
+                <div id="option-dynamic-fields"></div>
+            </form>
+        </div>
+
+        <div class="modal-footer-modern">
+            <button type="button" id="delete-option-btn" class="btn-delete" style="display: none;">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 0.875rem; height: 0.875rem; margin-right: 0.5rem;"><path d="m3 6 3 18h12l3-18"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
+                Delete Option
+            </button>
+            <div class="modal-actions">
+                <button type="button" id="cancel-option-btn" class="btn-cancel">Cancel</button>
+                <button type="submit" form="option-form" class="btn-save-modern">
+                    <span class="btn-text">Save Option</span>
+                    <span class="btn-loading" style="display: none;">
+                        <div class="spinner-modern"></div>
+                        Saving...
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Confirmation Modal -->
+<div id="confirmation-modal" class="modal-modern" style="display:none;" role="alertdialog" aria-modal="true" aria-labelledby="confirmation-modal-title" aria-describedby="confirmation-message">
+    <div class="modal-content-modern small">
+        <div class="modal-header-modern">
+            <h3 id="confirmation-modal-title">Confirm Delete</h3>
+        </div>
+        <div class="modal-body-modern">
+            <p id="confirmation-message">Are you sure you want to delete this? This action cannot be undone.</p>
+        </div>
+        <div class="modal-footer-modern">
+            <button type="button" class="btn-cancel cancel-delete-btn">Cancel</button>
+            <button type="button" class="btn-delete confirm-delete-btn">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 0.875rem; height: 0.875rem; margin-right: 0.5rem;"><path d="m3 6 3 18h12l3-18"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
+                <span class="btn-text">Delete</span>
+                <span class="btn-loading" style="display: none;">
+                    <div class="spinner-modern"></div>
+                    Deleting...
+                </span>
+            </button>
+        </div>
+    </div>
+</div>
+
+<style>
+/* Modern Compact Services Section Styles */
+.services-section.modern-compact {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0;
+}
+
+/* ===== MODERN LIST VIEW ===== */
+.services-header-modern {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+    padding: 1.5rem;
+    background: linear-gradient(135deg, hsl(var(--card)), hsl(var(--muted) / 0.3));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    box-shadow: 0 2px 8px hsl(var(--shadow) / 0.1);
+}
+
+.header-main {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    flex: 1;
+}
+
+.title-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.page-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
+.title-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    color: hsl(var(--primary));
+}
+
+.page-subtitle {
+    margin: 0;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.quick-stats {
+    display: flex;
+    gap: 1rem;
+}
+
+.stat-pill {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    font-size: 0.875rem;
+}
+
+.stat-pill.active {
+    background: linear-gradient(135deg, hsl(var(--success) / 0.1), hsl(var(--success) / 0.05));
+    border-color: hsl(var(--success) / 0.3);
+}
+
+.stat-number {
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
+.stat-label {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.75rem;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.filter-select-modern {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    background: hsl(var(--background));
+    font-size: 0.875rem;
+    min-width: 140px;
+}
+
+.btn-add-modern {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.9));
+    color: hsl(var(--primary-foreground));
+    border: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 4px hsl(var(--primary) / 0.2);
+}
+
+.btn-add-modern:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px hsl(var(--primary) / 0.3);
+}
+
+.btn-add-modern svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+/* Empty State */
+.empty-state-modern {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 4rem 2rem;
+    background: linear-gradient(135deg, hsl(var(--muted) / 0.3), hsl(var(--muted) / 0.1));
+    border: 2px dashed hsl(var(--border));
+    border-radius: 12px;
+    margin: 2rem 0;
+}
+
+.empty-visual {
+    margin-bottom: 2rem;
+}
+
+.empty-icon {
+    width: 4rem;
+    height: 4rem;
+    color: hsl(var(--primary));
+    opacity: 0.6;
+}
+
+.empty-content h3 {
+    margin: 0 0 1rem 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
+.empty-content p {
+    margin: 0 0 2rem 0;
+    color: hsl(var(--muted-foreground));
+    max-width: 400px;
+}
+
+.btn-create-first {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.9));
+    color: hsl(var(--primary-foreground));
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 12px hsl(var(--primary) / 0.2);
+}
+
+.btn-create-first:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px hsl(var(--primary) / 0.3);
+}
+
+/* Services Grid */
+.services-grid-modern {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+.service-card-modern {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow: hidden;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 8px hsl(var(--shadow) / 0.08);
+}
+
+.service-card-modern:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 32px hsl(var(--shadow) / 0.15);
+    border-color: hsl(var(--primary) / 0.3);
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem;
+    border-bottom: 1px solid hsl(var(--border));
+    background: linear-gradient(135deg, hsl(var(--muted) / 0.3), hsl(var(--muted) / 0.1));
+}
+
+.service-visual {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.service-icon,
+.service-image {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.service-icon {
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.8));
+    color: white;
+}
+
+.service-icon.default {
+    background: linear-gradient(135deg, hsl(var(--muted-foreground)), hsl(var(--muted-foreground) / 0.8));
+}
+
+.service-icon .dashicons {
+    font-size: 1.25rem;
+}
+
+.service-icon svg {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.service-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.status-indicator {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+}
+
+.status-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid hsl(var(--card));
+}
+
+.status-dot.active {
+    background: hsl(var(--success));
+}
+
+.status-dot.inactive {
+    background: hsl(var(--muted-foreground));
+}
+
+.card-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.action-btn {
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.action-btn:hover {
+    background: hsl(var(--accent));
+    border-color: hsl(var(--primary) / 0.3);
+}
+
+.action-btn.delete:hover {
+    background: hsl(var(--destructive));
+    border-color: hsl(var(--destructive));
+    color: white;
+}
+
+.action-btn svg {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+.card-content {
+    padding: 1.25rem;
+}
+
+.service-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+}
+
+.service-title h3 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.category-tag {
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.category-tag.residential {
+    background: hsl(var(--info) / 0.1);
+    color: hsl(var(--info));
+}
+
+.category-tag.commercial {
+    background: hsl(var(--warning) / 0.1);
+    color: hsl(var(--warning));
+}
+
+.category-tag.special {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+}
+
+.service-description {
+    margin: 0 0 1rem 0;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    line-height: 1.4;
+}
+
+.service-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.meta-item svg {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+.meta-item.price span {
+    font-weight: 700;
+    color: hsl(var(--success));
+}
+
+.card-footer {
+    padding: 1rem 1.25rem;
+    border-top: 1px solid hsl(var(--border));
+    background: hsl(var(--muted) / 0.2);
+}
+
+.btn-edit-modern {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.5rem;
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.btn-edit-modern:hover {
+    background: hsl(var(--primary) / 0.9);
+    transform: translateY(-1px);
+}
+
+/* ===== MODERN FORM VIEW ===== */
+.service-form-modern {
+    margin: 0 auto;
+}
+
+.breadcrumb-modern {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.875rem;
+}
+
+.breadcrumb-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.breadcrumb-link:hover {
+    color: hsl(var(--primary));
+}
+
+.breadcrumb-link svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.breadcrumb-separator {
+    width: 1rem;
+    height: 1rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.breadcrumb-current {
+    color: hsl(var(--foreground));
+    font-weight: 500;
+}
+
+.form-header-modern {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    padding: 1.5rem;
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.form-title-modern {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
+.service-status-badge {
+    padding: 0.25rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.service-status-badge.active {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+}
+
+.service-status-badge.inactive {
+    background: hsl(var(--muted-foreground) / 0.1);
+    color: hsl(var(--muted-foreground));
+}
+
+.btn-back-modern {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: all 0.2s ease;
+}
+
+.btn-back-modern:hover {
+    background: hsl(var(--accent));
+}
+
+.btn-back-modern svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+/* Compact Tabs */
+.tabs-modern {
+    margin-bottom: 1.5rem;
+}
+
+.tab-nav {
+    display: flex;
+    background: hsl(var(--muted));
+    border-radius: 8px;
+    padding: 0.25rem;
+    gap: 0.25rem;
+}
+
+.tab-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: hsl(var(--muted-foreground));
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+}
+
+.tab-btn:hover {
+    color: hsl(var(--foreground));
+    background: hsl(var(--background) / 0.5);
+}
+
+.tab-btn.active {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    box-shadow: 0 2px 4px hsl(var(--shadow) / 0.1);
+}
+
+.tab-badge {
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-radius: 4px;
+    padding: 0.125rem 0.375rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+}
+
+/* Form Styles */
+.service-form-compact {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow: hidden;
+    position: relative;
+    padding-bottom: 5rem; /* Space for fixed footer */
+}
+
+.tab-content {
+    display: none;
+    padding: 2rem;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+.form-section-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.field-label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.required {
+    color: hsl(var(--destructive));
+}
+
+.form-input {
+    padding: 0.75rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    background: hsl(var(--background));
+    font-size: 0.875rem;
+    transition: all 0.2s ease;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: hsl(var(--ring));
+    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+}
+
+.input-with-icon {
+    position: relative;
+}
+
+.input-icon {
+    position: absolute;
+    left: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1rem;
+    height: 1rem;
+    color: hsl(var(--muted-foreground));
+    pointer-events: none;
+}
+
+.input-with-icon .form-input {
+    padding-left: 2.5rem;
+}
+
+.input-with-suffix {
+    position: relative;
+}
+
+.input-suffix {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    pointer-events: none;
+}
+
+/* Appearance Section */
+.appearance-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.icon-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.current-icon {
+    width: 4rem;
+    height: 4rem;
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.8));
+    color: white;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
+}
+
+.current-icon .dashicons {
+    font-size: 1.5rem;
+}
+
+.current-icon svg {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.icon-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 0.5rem;
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    background: hsl(var(--muted) / 0.2);
+}
+
+.icon-option {
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    background: hsl(var(--background));
+    border: 1px solid transparent;
+}
+
+.icon-option:hover {
+    background: hsl(var(--accent));
+    border-color: hsl(var(--primary) / 0.3);
+}
+
+.icon-option.selected {
+    background: hsl(var(--primary));
+    color: white;
+}
+
+.icon-option .dashicons {
+    font-size: 1rem;
+}
+
+.image-upload-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.image-preview {
+    width: 120px;
+    height: 80px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: hsl(var(--muted) / 0.2);
+    margin: 0 auto;
+}
+
+.image-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.image-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    text-align: center;
+}
+
+.image-placeholder svg {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.image-placeholder span {
+    font-size: 0.75rem;
+}
+
+.image-controls {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.btn-select-image {
+    padding: 0.5rem 1rem;
+    background: hsl(var(--secondary));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-select-image:hover {
+    background: hsl(var(--accent));
+}
+
+/* Options Section */
+.options-header-compact {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.options-header-compact h3 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.options-header-compact p {
+    margin: 0;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.btn-add-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-add-option:hover:not(:disabled) {
+    background: hsl(var(--primary) / 0.9);
+}
+
+.btn-add-option:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn-add-option svg {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+.options-container-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+/* Fixed Footer */
+.form-footer-modern {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 2rem;
+    background: linear-gradient(135deg, hsl(var(--muted) / 0.5), hsl(var(--muted) / 0.3));
+    border-top: 1px solid hsl(var(--border));
+    backdrop-filter: blur(8px);
+}
+
+.footer-left,
+.footer-right {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.btn-delete {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+    background: hsl(var(--destructive));
+    color: hsl(var(--destructive-foreground));
+    border: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-delete:hover {
+    background: hsl(var(--destructive) / 0.9);
+    transform: translateY(-1px);
+}
+
+.btn-delete svg {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+.btn-save-modern {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.9));
+    color: hsl(var(--primary-foreground));
+    border: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 4px hsl(var(--primary) / 0.2);
+}
+
+.btn-save-modern:hover {
+    background: linear-gradient(135deg, hsl(var(--primary) / 0.9), hsl(var(--primary) / 0.8));
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px hsl(var(--primary) / 0.3);
+}
+
+.btn-save-modern svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.btn-loading {
+    display: none;
+}
+
+.loading .btn-text {
+    display: none;
+}
+
+.loading .btn-loading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.spinner-modern {
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid transparent;
+    border-top: 2px solid currentColor;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* ===== MODERN MODALS ===== */
+.modal-modern {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+}
+
+.modal-modern:not([style*="display: none"]) {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-content-modern {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+    width: 90vw;
+    max-width: 600px;
+    max-height: 90vh;
+    overflow: hidden;
+    animation: modalSlideUp 0.3s ease;
+}
+
+.modal-content-modern.small {
+    max-width: 400px;
+}
+
+@keyframes modalSlideUp {
+    from {
+        opacity: 0;
+        transform: translateY(2rem) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.modal-header-modern {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem 2rem;
+    border-bottom: 1px solid hsl(var(--border));
+    background: linear-gradient(135deg, hsl(var(--muted) / 0.3), hsl(var(--muted) / 0.1));
+}
+
+.modal-header-modern h3 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.modal-close-modern {
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.modal-close-modern:hover {
+    background: hsl(var(--destructive));
+    border-color: hsl(var(--destructive));
+    color: white;
+}
+
+.modal-close-modern svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.modal-body-modern {
+    padding: 2rem;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.modal-footer-modern {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 2rem;
+    border-top: 1px solid hsl(var(--border));
+    background: hsl(var(--muted) / 0.2);
+}
+
+.modal-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.btn-cancel {
+    padding: 0.5rem 1rem;
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-cancel:hover {
+    background: hsl(var(--accent));
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .services-header-modern {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: stretch;
+    }
+
+    .header-main {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .quick-stats {
+        justify-content: center;
+    }
+
+    .header-actions {
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .services-grid-modern {
+        grid-template-columns: 1fr;
+    }
+
+    .form-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .appearance-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .icon-grid {
+        grid-template-columns: repeat(5, 1fr);
+    }
+
+    .tab-nav {
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .form-footer-modern {
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1rem;
+    }
+
+    .footer-left,
+    .footer-right {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .modal-content-modern {
+        width: 95vw;
+        margin: 1rem;
+    }
+
+    .modal-header-modern,
+    .modal-body-modern,
+    .modal-footer-modern {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .modal-actions {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .page-title {
+        font-size: 1.25rem;
+    }
+
+    .title-icon {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    .service-card-modern {
+        margin: 0;
+    }
+
+    .card-header {
+        padding: 1rem;
+    }
+
+    .card-content {
+        padding: 1rem;
+    }
+
+    .service-meta {
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: flex-start;
+    }
+
+    .form-title-modern {
+        font-size: 1.25rem;
+    }
+
+    .tab-content {
+        padding: 1.5rem;
+    }
+
+    .icon-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+/* Dark mode adjustments */
+@media (prefers-color-scheme: dark) {
+    .services-header-modern,
+    .form-header-modern {
+        background: linear-gradient(135deg, hsl(var(--card)), hsl(var(--muted) / 0.2));
+    }
+
+    .modal-modern {
+        background: rgba(0, 0, 0, 0.8);
+    }
+}
+
+/* High contrast mode */
+@media (prefers-contrast: high) {
+    .service-card-modern,
+    .modal-content-modern {
+        border-width: 2px;
+    }
+
+    .btn-add-modern,
+    .btn-save-modern {
+        border: 2px solid hsl(var(--primary));
+    }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .service-card-modern:hover {
+        transform: none;
+    }
+}
+
+/* ===== Custom Styles for Image Upload and Options - START ===== */
+
+/* Styling for .choices-list in Options tab */
+.choices-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem; /* Space between choice items */
+    padding: 0.75rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 6px;
+    background-color: hsl(var(--muted) / 0.2);
+}
+
+.choice-item { /* Assuming this is a child of .choices-list */
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background-color: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+}
+
+.choice-item input[type="text"],
+.choice-item input[type="number"] {
+    flex-grow: 1;
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    font-size: 0.875rem;
+}
+
+.choice-item .remove-choice-btn { /* If there are remove buttons for choices */
+    padding: 0.25rem 0.5rem;
+    background-color: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+    border: 1px solid hsl(var(--destructive) / 0.3);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.75rem; /* Smaller font for compact button */
+}
+.choice-item .remove-choice-btn:hover {
+    background-color: hsl(var(--destructive) / 0.2);
+}
+
+/* Image Upload Specific Button Styling (ensuring consistency) */
+.image-section .image-controls {
+    display: flex;
+    flex-direction: column; /* Stack buttons vertically */
+    gap: 0.75rem; /* Space between buttons */
+    align-items: center; /* Center buttons */
+    width: 100%; /* Ensure controls take available width */
+    max-width: 250px; /* Match preview max-width if desired or adjust as needed */
+    margin: 0 auto; /* Center the controls block if it's narrower than section */
+}
+
+#btn-select-image-upload,
+#btn-replace-image,
+#btn-delete-image {
+    padding: 0.625rem 1rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: center;
+    width: 100%; /* Make buttons take full width of their container */
+}
+
+#btn-select-image-upload,
+#btn-replace-image {
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border: 1px solid hsl(var(--border));
+}
+#btn-select-image-upload:hover,
+#btn-replace-image:hover {
+    background: hsl(var(--accent));
+}
+
+#btn-delete-image {
+    background: hsl(var(--destructive));
+    color: hsl(var(--destructive-foreground));
+    border: 1px solid hsl(var(--destructive)); /* Matching border color */
+}
+#btn-delete-image:hover {
+    background: hsl(var(--destructive) / 0.9);
+}
+
+/* Ensure file input is hidden but accessible */
+#service-image-upload {
+    display: none;
+}
+
+/* Adjust image preview */
+.image-preview {
+    width: 100%; /* Make preview responsive */
+    max-width: 250px; /* Max width for preview */
+    height: auto; /* Adjust height automatically */
+    aspect-ratio: 16 / 9; /* Maintain aspect ratio */
+    margin-bottom: 1rem; /* Space below preview */
+    border: none; /* Remove default border as placeholder has its own */
+    background: transparent; /* Remove default background */
+}
+.image-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 6px; /* Match border radius of other elements */
+    border: 1px solid hsl(var(--border)); /* Add a subtle border to the image itself */
+}
+.image-placeholder {
+     display: flex;
+     flex-direction: column;
+     align-items: center;
+     justify-content: center;
+     width: 100%;
+     height: 100%;
+     border: 2px dashed hsl(var(--border));
+     border-radius: 6px;
+     color: hsl(var(--muted-foreground));
+     background-color: hsl(var(--muted) / 0.1);
+}
+.image-placeholder svg {
+    width: 2rem;
+    height: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+/* General UI Consistency */
+.form-section-compact .appearance-grid,
+.form-section-compact .options-header-compact,
+.form-section-compact .options-container-compact {
+    margin-bottom: 1.5rem; /* Add some bottom margin to sections */
+}
+
+/* Ensure field labels are consistent */
+.field-label {
+    display: block; /* Ensure labels take full width if needed */
+    margin-bottom: 0.375rem; /* Consistent spacing below labels */
+    font-weight: 600; /* Slightly bolder labels */
+    color: hsl(var(--foreground)); /* Ensure consistent color */
+}
+
+/* Options tab button styling (Add Option) */
+#add-option-btn {
+    padding: 0.625rem 1rem; /* Standardized padding */
+    font-weight: 500; /* Consistent font weight */
+}
+
+/* Style for option cards if they exist within .options-container-compact */
+.option-card-compact { /* Assuming a class for individual option items */
+    padding: 1rem;
+    background: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    box-shadow: 0 1px 3px hsl(var(--shadow) / 0.05);
+    transition: box-shadow 0.2s ease;
+}
+.option-card-compact:hover {
+    box-shadow: 0 4px 12px hsl(var(--shadow) / 0.1);
+}
+
+.option-card-compact + .option-card-compact {
+    margin-top: 1rem; /* Space between option cards */
+}
+.option-card-header { /* If option cards have headers */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid hsl(var(--border));
+}
+.option-card-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+.option-card-actions button,
+.option-card-actions .btn-icon { /* Assuming .btn-icon for icon-only buttons */
+    margin-left: 0.5rem;
+    padding: 0.375rem 0.75rem; /* Standard padding for text buttons */
+    font-size: 0.8125rem;
+}
+
+/* Icon only button styling for option card actions */
+.btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem; /* Fixed width */
+    height: 2rem; /* Fixed height */
+    padding: 0; /* Remove padding if fixed size */
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.btn-icon:hover {
+    background: hsl(var(--accent));
+    border-color: hsl(var(--primary) / 0.3);
+}
+.btn-icon svg {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+.btn-icon.delete:hover {
+    background: hsl(var(--destructive) / 0.1);
+    border-color: hsl(var(--destructive) / 0.3);
+    color: hsl(var(--destructive));
+}
+/* ===== Custom Styles for Image Upload and Options - END ===== */
+
+</style>
+
+<script>
+// Modern compact JavaScript enhancements
+document.addEventListener('DOMContentLoaded', function() {
+    // Enhanced service card interactions
+    const serviceCards = document.querySelectorAll('.service-card-modern');
+    serviceCards.forEach(card => {
+        card.addEventListener('mouseenter', function() {
+            this.style.setProperty('--hover-scale', '1.02');
+        });
+
+        card.addEventListener('mouseleave', function() {
+            this.style.removeProperty('--hover-scale');
+        });
+    });
+
+    // Smooth tab transitions
+    const tabButtons = document.querySelectorAll('.tab-btn');
+    const tabContents = document.querySelectorAll('.tab-content');
+
+    tabButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const tabId = this.dataset.tab;
+
+            // Remove active states
+            tabButtons.forEach(btn => btn.classList.remove('active'));
+            tabContents.forEach(content => content.classList.remove('active'));
+
+            // Add active states
+            this.classList.add('active');
+            document.getElementById(tabId).classList.add('active');
+
+            // Update URL
+            const url = new URL(window.location);
+            url.searchParams.set('active_tab', tabId);
+            window.history.replaceState({}, '', url);
+        });
+    });
+
+    // Enhanced icon selection
+    const iconOptions = document.querySelectorAll('.icon-option');
+    const currentIcon = document.querySelector('.current-icon');
+    const iconInput = document.getElementById('service-icon');
+
+    iconOptions.forEach(option => {
+        option.addEventListener('click', function() {
+            const iconClass = this.dataset.icon;
+
+            // Update selection
+            iconOptions.forEach(opt => opt.classList.remove('selected'));
+            this.classList.add('selected');
+
+            // Update current icon display
+            if (currentIcon) {
+                currentIcon.innerHTML = `<span class="dashicons ${iconClass}"></span>`;
+            }
+
+            // Update hidden input
+            if (iconInput) {
+                iconInput.value = iconClass;
+            }
+
+            // Add selection feedback
+            this.style.transform = 'scale(1.1)';
+            setTimeout(() => {
+                this.style.transform = '';
+            }, 200);
+        });
+    });
+
+    // Enhanced filter functionality
+    const categoryFilter = document.getElementById('category-filter');
+    if (categoryFilter) {
+        categoryFilter.addEventListener('change', function() {
+            const selectedCategory = this.value;
+            const serviceCards = document.querySelectorAll('.service-card-modern');
+
+            serviceCards.forEach(card => {
+                const cardCategory = card.dataset.category;
+
+                if (!selectedCategory || cardCategory === selectedCategory) {
+                    card.style.display = '';
+                    card.style.animation = 'fadeIn 0.3s ease';
+                } else {
+                    card.style.display = 'none';
+                }
+            });
+        });
+    }
+
+    // Edit button click handlers
+    document.querySelectorAll('.action-btn.edit').forEach(btn => {
+        btn.addEventListener('click', function() {
+            const serviceId = this.dataset.id;
+            const editUrl = new URL(window.location.origin + window.location.pathname);
+            editUrl.searchParams.set('view', 'edit');
+            editUrl.searchParams.set('service_id', serviceId);
+            window.location.href = editUrl.toString();
+        });
+    });
+
+    // Form validation enhancements
+    const serviceForm = document.getElementById('service-form');
+    if (serviceForm) {
+        const inputs = serviceForm.querySelectorAll('input[required]');
+
+        inputs.forEach(input => {
+            input.addEventListener('blur', function() {
+                if (!this.value.trim()) {
+                    this.style.borderColor = 'hsl(var(--destructive))';
+                    this.style.boxShadow = '0 0 0 2px hsl(var(--destructive) / 0.2)';
+                } else {
+                    this.style.borderColor = '';
+                    this.style.boxShadow = '';
+                }
+            });
+
+            input.addEventListener('input', function() {
+                if (this.value.trim()) {
+                    this.style.borderColor = '';
+                    this.style.boxShadow = '';
+                }
+            });
+        });
+    }
+
+    // Loading state for buttons
+    function setButtonLoading(button, loading) {
+        const btnText = button.querySelector('.btn-text');
+        const btnLoading = button.querySelector('.btn-loading');
+
+        if (loading) {
+            button.disabled = true;
+            button.classList.add('loading');
+            if (btnText) btnText.style.display = 'none';
+            if (btnLoading) btnLoading.style.display = 'flex';
+        } else {
+            button.disabled = false;
+            button.classList.remove('loading');
+            if (btnText) btnText.style.display = '';
+            if (btnLoading) btnLoading.style.display = 'none';
+        }
+    }
+
+    // Make setButtonLoading globally available
+    window.setButtonLoading = setButtonLoading;
+
+    // --- MODAL HANDLING START --- //
+    // Modal DOM Elements
+    const optionModal = document.getElementById('option-modal');
+    const confirmationModal = document.getElementById('confirmation-modal');
+
+    // Option Modal Specific Elements
+    const addOptionBtn = document.getElementById('add-option-btn');
+    const optionForm = document.getElementById('option-form');
+    const optionModalTitle = document.getElementById('option-modal-title');
+    const optionIdInput = document.getElementById('option-id'); // Hidden input for option ID
+    const optionServiceIdInput = document.getElementById('option-service-id'); // Hidden input for service ID in option
+    const deleteOptionBtnInModal = document.getElementById('delete-option-btn');
+    const serviceOptionsContainer = document.getElementById('service-options-container'); // For edit option event delegation
+
+    // Confirmation Modal Specific Elements
+    const confirmationMessage = document.getElementById('confirmation-message');
+    const confirmDeleteBtn = confirmationModal ? confirmationModal.querySelector('.confirm-delete-btn') : null;
+
+    // General Service Form Elements (used for context)
+    const serviceIdInput = document.getElementById('service-id'); // Main service ID on the page
+
+    // Modal State Variables
+    let activeModal = null;       // Tracks the currently displayed modal
+    let lastFocusedElement = null; // Stores the element that had focus before modal opening, to restore focus on close
+
+    /**
+     * Opens a specified modal.
+     * @param {HTMLElement} modal - The modal element to open.
+     * @param {string} focusElementSelector - A CSS selector for the element to focus within the modal.
+     */
+    function openModal(modal, focusElementSelector) {
+        if (!modal) return;
+
+        lastFocusedElement = document.activeElement; // Store current focus
+        modal.style.display = 'flex';
+
+        setTimeout(() => { // Allow display change to register before adding class for transition
+            modal.classList.add('active');
+            activeModal = modal;
+            const focusElement = modal.querySelector(focusElementSelector);
+            if (focusElement) {
+                focusElement.focus();
+            }
+        }, 10);
+    }
+
+    /**
+     * Closes a specified modal.
+     * @param {HTMLElement} modal - The modal element to close.
+     */
+    function closeModal(modal) {
+        if (!modal) return;
+
+        modal.classList.remove('active');
+
+        setTimeout(() => { // Allow transition to complete before hiding
+            modal.style.display = 'none';
+            if (activeModal === modal) {
+                activeModal = null;
+            }
+            if (lastFocusedElement) {
+                lastFocusedElement.focus(); // Restore focus to the element that opened the modal
+                lastFocusedElement = null;
+            }
+        }, 300); // Duration should match CSS transition duration
+    }
+
+    /**
+     * Resets the Option Modal to its default state (for adding a new option).
+     */
+    function resetOptionModal() {
+        if (optionForm) optionForm.reset();
+        if (optionModalTitle) optionModalTitle.textContent = 'Add New Option';
+        if (optionIdInput) optionIdInput.value = '';
+        if (deleteOptionBtnInModal) deleteOptionBtnInModal.style.display = 'none';
+
+        const dynamicFieldsContainer = document.getElementById('option-dynamic-fields');
+        if (dynamicFieldsContainer) dynamicFieldsContainer.innerHTML = ''; // Clear any dynamically added fields
+
+        const priceImpactGroup = document.getElementById('price-impact-group');
+        if (priceImpactGroup) priceImpactGroup.style.display = 'block'; // Or based on default visibility logic
+    }
+
+    /**
+     * Resets the Confirmation Modal to its default state.
+     */
+    function resetConfirmationModal() {
+        if (confirmationMessage) confirmationMessage.textContent = 'Are you sure you want to delete this? This action cannot be undone.';
+        if (confirmDeleteBtn) {
+            confirmDeleteBtn.removeAttribute('data-item-id');
+            confirmDeleteBtn.removeAttribute('data-item-type');
+        }
+    }
+
+    // --- Event Listeners for Opening Modals ---
+
+    // Open Option Modal for Adding New Option
+    if (addOptionBtn && optionModal) {
+        addOptionBtn.addEventListener('click', function() {
+            if (this.disabled) return; // Respect disabled state (e.g., if service not saved yet)
+
+            resetOptionModal();
+            if (optionServiceIdInput && serviceIdInput) {
+                optionServiceIdInput.value = serviceIdInput.value; // Pass current service ID
+            }
+            // Title and button visibility are handled by resetOptionModal for "add" case
+            openModal(optionModal, '#option-name');
+        });
+    }
+
+    /**
+     * Mock function to simulate fetching option data for editing.
+     * In a real application, this would involve an AJAX request to the server.
+     * @param {string} optionId - The ID of the option to fetch.
+     * @param {string} serviceId - The ID of the parent service.
+     * @returns {object} Mock option data.
+     */
+    function fetchMockOptionData(optionId, serviceId) {
+        console.log(`Fetching mock data for optionId: ${optionId}, serviceId: ${serviceId}`);
+        // Simulate data structure that might come from a backend
+        return {
+            id: optionId,
+            service_id: serviceId,
+            name: `Mock Option ${optionId.replace('opt_', '')}`,
+            type: (parseInt(optionId.slice(-1)) % 3 === 0) ? 'select' : (parseInt(optionId.slice(-1)) % 2 === 0) ? 'text' : 'checkbox',
+            description: `This is a detailed mock description for option ${optionId}. It helps illustrate how content might fill the modal.`,
+            is_required: (parseInt(optionId.slice(-1)) % 2 === 0) ? '1' : '0',
+            price_type: (parseInt(optionId.slice(-1)) % 3 === 0) ? 'percentage' : 'fixed',
+            price_impact: (parseInt(optionId.slice(-1)) * 5 + 5).toFixed(2), // e.g., 5.00, 10.00, 15.00
+            // Example 'values' for select/radio types - actual population of these is a TODO
+            values: (parseInt(optionId.slice(-1)) % 3 === 0) ? [{value: 'val1', label: 'Value 1'}, {value: 'val2', label: 'Value 2'}] : []
+        };
+    }
+
+    // Open Option Modal for Editing Existing Option (Event Delegation)
+    if (serviceOptionsContainer && optionModal) {
+        serviceOptionsContainer.addEventListener('click', function(event) {
+            const editButton = event.target.closest('.edit-option-btn');
+            if (!editButton) return;
+
+            const optionId = editButton.dataset.optionId;
+            const currentServiceId = serviceIdInput ? serviceIdInput.value : null;
+
+            if (!optionId) {
+                console.error('Edit option button clicked: missing data-option-id attribute.');
+                return;
+            }
+            if (!currentServiceId) {
+                console.error('Cannot edit option: main service ID is not available.');
+                // Potentially show a user-facing error here.
+                return;
+            }
+
+            resetOptionModal();
+
+            const mockData = fetchMockOptionData(optionId, currentServiceId);
+
+            if (optionModalTitle) optionModalTitle.textContent = 'Edit Option';
+            if (optionIdInput) optionIdInput.value = mockData.id;
+            if (optionServiceIdInput) optionServiceIdInput.value = mockData.service_id;
+
+            // Populate form fields
+            const fields = {
+                'option-name': mockData.name,
+                'option-type': mockData.type,
+                'option-description': mockData.description,
+                'option-required': mockData.is_required,
+                'option-price-type': mockData.price_type,
+                'option-price-impact': mockData.price_impact
+            };
+
+            for (const [id, value] of Object.entries(fields)) {
+                const element = document.getElementById(id);
+                if (element) element.value = value;
+            }
+
+            // TODO: Handle dynamic fields based on mockData.type (e.g., populating select options)
+            // const dynamicFieldsContainer = document.getElementById('option-dynamic-fields');
+            // if (dynamicFieldsContainer) {
+            //    dynamicFieldsContainer.innerHTML = `<p>Dynamic fields for type '${mockData.type}' need implementation.</p>`;
+            // }
+
+            if (deleteOptionBtnInModal) deleteOptionBtnInModal.style.display = 'flex';
+            openModal(optionModal, '#option-name');
+        });
+    }
+
+    // Open Confirmation Modal (Event Delegation on document.body)
+    // Handles both "Delete Service" and "Delete Option" buttons
+    document.body.addEventListener('click', function(event) {
+        const target = event.target;
+        const deleteServiceButton = target.closest('.delete-service-btn');
+        const deleteOptionButton = target.closest('#delete-option-btn') || target.closest('.delete-option-btn-list');
+
+        let itemId = null;
+        let itemType = null;
+        let message = '';
+
+        if (deleteServiceButton) {
+            itemId = deleteServiceButton.dataset.id;
+            itemType = 'service';
+            message = 'Are you sure you want to delete this service? This action cannot be undone.';
+        } else if (deleteOptionButton) {
+            itemId = deleteOptionButton.dataset.optionId || (optionIdInput ? optionIdInput.value : null);
+            itemType = 'option';
+            message = 'Are you sure you want to delete this option? This action cannot be undone.';
+        }
+
+        if (itemId && itemType) {
+            if (!confirmationModal) return;
+            resetConfirmationModal();
+            if (confirmationMessage) confirmationMessage.textContent = message;
+            if (confirmDeleteBtn) {
+                confirmDeleteBtn.setAttribute('data-item-id', itemId);
+                confirmDeleteBtn.setAttribute('data-item-type', itemType);
+            }
+            openModal(confirmationModal, '.cancel-delete-btn');
+        }
+    });
+
+    // --- Event Listeners for Closing Modals ---
+
+    // Generic Close Handlers (X button, Click Outside)
+    [optionModal, confirmationModal].forEach(modal => {
+        if (!modal) return;
+
+        const closeBtn = modal.querySelector('.modal-close-modern');
+        if (closeBtn) {
+            closeBtn.addEventListener('click', () => {
+                closeModal(modal);
+                if (modal === optionModal) resetOptionModal();
+                else if (modal === confirmationModal) resetConfirmationModal();
+            });
+        }
+
+        modal.addEventListener('click', function(event) { // Click outside
+            if (event.target === modal) {
+                closeModal(modal);
+                if (modal === optionModal) resetOptionModal();
+                else if (modal === confirmationModal) resetConfirmationModal();
+            }
+        });
+    });
+
+    // Specific Cancel Buttons
+    const cancelOptionBtn = document.getElementById('cancel-option-btn');
+    if (cancelOptionBtn && optionModal) {
+        cancelOptionBtn.addEventListener('click', () => {
+            closeModal(optionModal);
+            resetOptionModal();
+        });
+    }
+
+    const cancelDeleteBtn = confirmationModal ? confirmationModal.querySelector('.cancel-delete-btn') : null;
+    if (cancelDeleteBtn && confirmationModal) {
+        cancelDeleteBtn.addEventListener('click', () => {
+            closeModal(confirmationModal);
+            resetConfirmationModal();
+        });
+    }
+
+    // --- Global Accessibility Enhancements for Modals (Escape Key & Focus Trapping) ---
+    document.addEventListener('keydown', function(event) {
+        if (!activeModal) return; // Only act if a modal is active
+
+        // Escape Key: Close active modal
+        if (event.key === 'Escape') {
+            closeModal(activeModal);
+            if (activeModal === optionModal) resetOptionModal();
+            else if (activeModal === confirmationModal) resetConfirmationModal();
+        }
+
+        // Tab Key: Trap focus within the active modal
+        if (event.key === 'Tab') {
+            const focusableElements = Array.from(activeModal.querySelectorAll(
+                'a[href]:not([disabled]), button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )).filter(el => el.offsetParent !== null); // Ensure element is visible
+
+            if (!focusableElements.length) { // Should not happen with well-structured modals
+                event.preventDefault();
+                return;
+            }
+
+            const firstElement = focusableElements[0];
+            const lastElement = focusableElements[focusableElements.length - 1];
+            const currentFocus = document.activeElement;
+
+            if (event.shiftKey) { // Shift + Tab (moving backwards)
+                if (currentFocus === firstElement || !focusableElements.includes(currentFocus)) {
+                    event.preventDefault();
+                    lastElement.focus(); // Wrap to last element
+                }
+            } else { // Tab (moving forwards)
+                if (currentFocus === lastElement || !focusableElements.includes(currentFocus)) {
+                    event.preventDefault();
+                    firstElement.focus(); // Wrap to first element
+                }
+            }
+        }
+    });
+    // --- MODAL HANDLING END --- //
+
+    // --- IMAGE UPLOAD START --- //
+    // Element declarations for image upload feature
+    const serviceImageUpload = document.getElementById('service-image-upload');
+    const btnSelectImageUpload = document.getElementById('btn-select-image-upload');
+    const imagePreviewDiv = document.querySelector('.image-section .image-preview');
+    const btnReplaceImage = document.getElementById('btn-replace-image');
+    const btnDeleteImage = document.getElementById('btn-delete-image');
+    const serviceImageUrlInput = document.getElementById('service-image-url');
+
+    // Note: `serviceForm`, `saveServiceButton`, `addOptionBtn` are assumed to be declared in an outer scope
+    // if they are used by other parts of the script (like modals). If not, they should be obtained here.
+    // For robustness, let's re-fetch saveServiceButton if it's only used in this submission context,
+    // or ensure it's correctly fetched if global.
+    // const saveServiceButton = document.getElementById('save-service-button'); // Re-fetch or use global
+
+    function updateImagePreviewUI(imageUrl) {
+        // Ensure imagePreviewDiv exists before trying to manipulate it
+        if (!imagePreviewDiv) {
+            // console.warn('imagePreviewDiv not found for UI update.');
+            return;
+        }
+
+        if (imageUrl) {
+            imagePreviewDiv.innerHTML = `<img src="${imageUrl}" alt="Service image">`;
+            if (btnSelectImageUpload) btnSelectImageUpload.style.display = 'none';
+            if (btnReplaceImage) btnReplaceImage.style.display = 'inline-block';
+            if (btnDeleteImage) btnDeleteImage.style.display = 'inline-block';
+        } else {
+            imagePreviewDiv.innerHTML = `
+                <div class="image-placeholder">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>
+                        <circle cx="9" cy="9" r="2"/>
+                        <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
+                    </svg>
+                    <span>No image</span>
+                </div>`;
+            if (btnSelectImageUpload) btnSelectImageUpload.style.display = 'inline-block';
+            if (btnReplaceImage) btnReplaceImage.style.display = 'none';
+            if (btnDeleteImage) btnDeleteImage.style.display = 'none';
+        }
+    }
+
+    // Initial state logic - only if the relevant elements are on the page
+    if (serviceImageUrlInput && imagePreviewDiv) {
+        if (serviceImageUrlInput.value) {
+            updateImagePreviewUI(serviceImageUrlInput.value);
+        } else {
+            updateImagePreviewUI(null); // Show placeholder
+        }
+    }
+
+    // Event Listeners with null checks
+    if (btnSelectImageUpload) {
+        btnSelectImageUpload.addEventListener('click', () => {
+            if (serviceImageUpload) serviceImageUpload.click();
+        });
+    }
+
+    if (btnReplaceImage) {
+        btnReplaceImage.addEventListener('click', () => {
+            if (serviceImageUpload) serviceImageUpload.click();
+        });
+    }
+
+    if (serviceImageUpload) {
+        serviceImageUpload.addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            if (!file) return;
+
+            const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+            if (!allowedTypes.includes(file.type)) {
+                alert('Invalid file type. Please select a JPG, PNG, WEBP or GIF image.');
+                this.value = '';
+                return;
+            }
+
+            const maxSize = 2 * 1024 * 1024; // 2MB
+            if (file.size > maxSize) {
+                alert('File is too large. Maximum size is 2MB.');
+                this.value = '';
+                return;
+            }
+
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                if (imagePreviewDiv) {
+                    imagePreviewDiv.innerHTML = `<img src="${e.target.result}" alt="Service image preview">`;
+                }
+                // Show/hide appropriate buttons
+                if (btnSelectImageUpload) btnSelectImageUpload.style.display = 'none';
+                if (btnReplaceImage) btnReplaceImage.style.display = 'inline-block';
+                if (btnDeleteImage) btnDeleteImage.style.display = 'inline-block';
+            }
+            reader.readAsDataURL(file);
+        });
+    }
+
+    if (btnDeleteImage) {
+        btnDeleteImage.addEventListener('click', () => {
+            if (serviceImageUrlInput) serviceImageUrlInput.value = '';
+            if (serviceImageUpload) serviceImageUpload.value = '';
+            updateImagePreviewUI(null); // Reset to placeholder and correct button visibility
+        });
+    }
+
+    // Main service form submission logic (assuming 'serviceForm' is available from outer scope or re-fetched)
+    // const serviceForm = document.getElementById('service-form'); // Already declared in outer scope
+    const localSaveServiceButton = document.getElementById('save-service-button'); // Use local var for clarity
+    const localAddOptionBtn = document.getElementById('add-option-btn'); // Use local var for clarity
+
+    if (serviceForm && localSaveServiceButton) {
+        serviceForm.addEventListener('submit', function(event) {
+            event.preventDefault();
+            if (window.setButtonLoading) { // Check if function exists
+                window.setButtonLoading(localSaveServiceButton, true);
+            }
+
+            const processSaveService = () => {
+                const formData = new FormData(this);
+                const serviceIdElement = document.getElementById('service-id');
+                const serviceId = serviceIdElement ? serviceIdElement.value : null;
+                formData.append('action', 'mobooking_save_service');
+                // Main nonce ('nonce') is already included in formData by virtue of being an input field
+
+                fetch(window.mobookingDashboard.ajaxUrl, { method: 'POST', body: formData })
+                .then(response => response.json())
+                .then(data => {
+                    if (window.setButtonLoading) {
+                        window.setButtonLoading(localSaveServiceButton, false);
+                    }
+                    if (data.success) {
+                        console.log('Service saved:', data);
+                        alert('Service saved successfully!');
+                        if (!serviceId && data.data && data.data.service_id) { // New service saved
+                             const newUrl = new URL(window.location);
+                             newUrl.searchParams.set('view', 'edit');
+                             newUrl.searchParams.set('service_id', data.data.service_id);
+                             const currentActiveTab = new URLSearchParams(window.location.search).get('active_tab') || 'basic-info';
+                             newUrl.searchParams.set('active_tab', data.data.active_tab || currentActiveTab);
+                             window.history.replaceState({path:newUrl.href},'',newUrl.href); // Update URL without reload
+
+                             if(serviceIdElement) serviceIdElement.value = data.data.service_id; // Update hidden ID
+
+                             const optionServiceIdField = document.getElementById('option-service-id');
+                             if(optionServiceIdField) optionServiceIdField.value = data.data.service_id; // Update option modal's service ID
+
+                             if(localAddOptionBtn) { // Enable 'Add Option' button
+                                localAddOptionBtn.disabled = false;
+                                localAddOptionBtn.title = '';
+                             }
+                             const formTitle = document.querySelector('.form-title-modern'); // Update page title
+                             if (formTitle && formTitle.textContent.trim() === 'New Service' && data.data.name) {
+                                formTitle.textContent = data.data.name;
+                             }
+                        } else if (serviceId && data.data && data.data.name) { // Existing service updated
+                            const formTitle = document.querySelector('.form-title-modern');
+                            if (formTitle && formTitle.textContent.trim() !== data.data.name) { // Update title if name changed
+                               formTitle.textContent = data.data.name;
+                            }
+                        }
+                    } else {
+                        alert('Error saving service: ' + (data.data && data.data.message ? data.data.message : 'Unknown error'));
+                    }
+                })
+                .catch(error => {
+                    if (window.setButtonLoading) {
+                        window.setButtonLoading(localSaveServiceButton, false);
+                    }
+                    console.error('Error saving service:', error);
+                    alert('An unexpected error occurred while saving the service.');
+                });
+            };
+
+            if (serviceImageUpload && serviceImageUpload.files.length > 0) { // Check if a file is selected
+                const imageFile = serviceImageUpload.files[0];
+                const imageFormData = new FormData();
+                imageFormData.append('action', 'mobooking_upload_service_image');
+                imageFormData.append('service_image', imageFile);
+
+                const imageNonceField = document.querySelector('#image_upload_nonce_field');
+                if (imageNonceField && imageNonceField.value) { // Check nonce field and its value
+                    imageFormData.append('nonce', imageNonceField.value);
+                } else {
+                    console.error('Image upload nonce field not found or empty.');
+                    alert('Security token missing for image upload. Please refresh and try again.');
+                    if (window.setButtonLoading && localSaveServiceButton) { // Check local var
+                        window.setButtonLoading(localSaveServiceButton, false);
+                    }
+                    return; // Stop submission
+                }
+
+                const serviceIdElement = document.getElementById('service-id');
+                const currentServiceId = serviceIdElement ? serviceIdElement.value : null;
+                if (currentServiceId) {
+                    imageFormData.append('service_id', currentServiceId);
+                }
+
+                fetch(window.mobookingDashboard.ajaxUrl, {
+                    method: 'POST',
+                    body: imageFormData,
+                    //contentType: false, // Not needed for fetch() with FormData
+                    //processData: false, // Not needed for fetch()
+                })
+                .then(response => response.json())
+                .then(uploadData => {
+                    if (uploadData.success && uploadData.data && uploadData.data.url) {
+                        if (serviceImageUrlInput) serviceImageUrlInput.value = uploadData.data.url; // Set hidden input
+                        if (serviceImageUpload) serviceImageUpload.value = ''; // Clear file input
+                        updateImagePreviewUI(uploadData.data.url); // Update preview with final URL
+                        processSaveService(); // Proceed to save the rest of the service data
+                    } else {
+                        if (window.setButtonLoading && localSaveServiceButton) {
+                            window.setButtonLoading(localSaveServiceButton, false);
+                        }
+                        alert('Error uploading image: ' + (uploadData.data && uploadData.data.message ? uploadData.data.message : 'Unknown error'));
+                    }
+                })
+                .catch(error => {
+                    if (window.setButtonLoading && localSaveServiceButton) {
+                        window.setButtonLoading(localSaveServiceButton, false);
+                    }
+                    console.error('Error uploading image:', error);
+                    alert('An unexpected error occurred while uploading the image.');
+                });
+            } else {
+                processSaveService(); // No new image, just save service data
+            }
+        });
+    }
+    // --- IMAGE UPLOAD END --- //
+});
+
+// CSS animation for fade in
+const fadeInKeyframes = `
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+`;
+
+// Add keyframes to document
+const styleSheet = document.createElement('style');
+styleSheet.textContent = fadeInKeyframes;
+document.head.appendChild(styleSheet);
+</script>

--- a/page-settings.php
+++ b/page-settings.php
@@ -1,0 +1,2138 @@
+<?php
+// dashboard/sections/settings.php - Business Settings Management
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Initialize settings manager
+$settings_manager = new \MoBooking\Database\SettingsManager();
+$settings = $settings_manager->get_settings($user_id);
+
+// Get user data
+$user_data = get_userdata($user_id);
+?>
+
+<div class="settings-section">
+    <div class="settings-header">
+        <div class="settings-header-content">
+            <div class="settings-title-group">
+                <h1 class="settings-main-title">
+                    <svg class="title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="12" cy="12" r="3"></circle>
+                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                    </svg>
+                    <?php _e('Business Settings', 'mobooking'); ?>
+                </h1>
+                <p class="settings-subtitle"><?php _e('Configure your business information and preferences', 'mobooking'); ?></p>
+            </div>
+
+            <div class="settings-status">
+                <div class="status-indicator">
+                    <div class="status-dot active"></div>
+                    <span class="status-text"><?php _e('Settings Active', 'mobooking'); ?></span>
+                </div>
+            </div>
+        </div>
+
+        <div class="settings-header-actions">
+            <button type="button" id="preview-settings-btn" class="btn-secondary">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                    <circle cx="12" cy="12" r="3"></circle>
+                </svg>
+                <?php _e('Preview', 'mobooking'); ?>
+            </button>
+
+            <button type="button" id="reset-settings-btn" class="btn-secondary">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="1 4 1 10 7 10"></polyline>
+                    <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                </svg>
+                <?php _e('Reset', 'mobooking'); ?>
+            </button>
+        </div>
+    </div>
+
+    <!-- Settings Navigation Tabs -->
+    <div class="settings-tabs">
+        <div class="tab-list" role="tablist">
+            <button type="button" class="tab-button active" data-tab="business" role="tab" aria-controls="business" aria-selected="true">
+                <div class="tab-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                        <polyline points="9,22 9,12 15,12 15,22"></polyline>
+                    </svg>
+                </div>
+                <span><?php _e('Business Info', 'mobooking'); ?></span>
+            </button>
+
+            <button type="button" class="tab-button" data-tab="branding" role="tab" aria-controls="branding" aria-selected="false">
+                <div class="tab-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="18" cy="5" r="3"></circle>
+                        <circle cx="6" cy="12" r="3"></circle>
+                        <circle cx="18" cy="19" r="3"></circle>
+                        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+                        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+                    </svg>
+                </div>
+                <span><?php _e('Branding', 'mobooking'); ?></span>
+            </button>
+
+            <button type="button" class="tab-button" data-tab="notifications" role="tab" aria-controls="notifications" aria-selected="false">
+                <div class="tab-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                        <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+                    </svg>
+                </div>
+                <span><?php _e('Notifications', 'mobooking'); ?></span>
+            </button>
+
+            <button type="button" class="tab-button" data-tab="advanced" role="tab" aria-controls="advanced" aria-selected="false">
+                <div class="tab-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="16 18 22 12 16 6"></polyline>
+                        <polyline points="8 6 2 12 8 18"></polyline>
+                    </svg>
+                </div>
+                <span><?php _e('Advanced', 'mobooking'); ?></span>
+            </button>
+        </div>
+    </div>
+
+    <!-- Settings Form -->
+    <form id="settings-form" class="settings-container">
+        <?php wp_nonce_field('mobooking-settings-nonce', 'nonce'); ?>
+
+        <!-- Business Information Tab -->
+        <div id="business" class="tab-pane active" role="tabpanel">
+            <div class="settings-section-wrapper">
+                <div class="section-header">
+                    <h2 class="section-title"><?php _e('Business Information', 'mobooking'); ?></h2>
+                    <p class="section-description"><?php _e('Configure your basic business details and contact information', 'mobooking'); ?></p>
+                </div>
+
+                <div class="settings-fields">
+                    <div class="field-row">
+                        <div class="field-group">
+                            <label for="company-name" class="field-label required"><?php _e('Company Name', 'mobooking'); ?></label>
+                            <input type="text" id="company-name" name="company_name" class="form-control"
+                                   value="<?php echo esc_attr($settings->company_name); ?>"
+                                   placeholder="<?php _e('Your Company Name', 'mobooking'); ?>" required>
+                            <p class="field-help"><?php _e('This name will appear on your booking forms and emails', 'mobooking'); ?></p>
+                        </div>
+
+                        <div class="field-group">
+                            <label for="company-phone" class="field-label"><?php _e('Phone Number', 'mobooking'); ?></label>
+                            <input type="tel" id="company-phone" name="phone" class="form-control"
+                                   value="<?php echo esc_attr($settings->phone); ?>"
+                                   placeholder="<?php _e('(555) 123-4567', 'mobooking'); ?>">
+                            <p class="field-help"><?php _e('Contact phone number for customer inquiries', 'mobooking'); ?></p>
+                        </div>
+                    </div>
+
+                    <div class="field-group">
+                        <label for="company-email" class="field-label"><?php _e('Business Email', 'mobooking'); ?></label>
+                        <input type="email" id="company-email" name="business_email" class="form-control"
+                               value="<?php echo esc_attr($user_data->user_email); ?>"
+                               placeholder="<?php _e('business@example.com', 'mobooking'); ?>">
+                        <p class="field-help"><?php _e('Primary email for business communications', 'mobooking'); ?></p>
+                    </div>
+
+                    <div class="field-group">
+                        <label for="company-address" class="field-label"><?php _e('Business Address', 'mobooking'); ?></label>
+                        <textarea id="company-address" name="business_address" class="form-control" rows="3"
+                                  placeholder="<?php _e('123 Business St, City, State 12345', 'mobooking'); ?>"><?php echo esc_textarea(get_user_meta($user_id, 'business_address', true)); ?></textarea>
+                        <p class="field-help"><?php _e('Your business address (optional)', 'mobooking'); ?></p>
+                    </div>
+
+                    <div class="field-group">
+                        <label for="company-website" class="field-label"><?php _e('Website', 'mobooking'); ?></label>
+                        <input type="url" id="company-website" name="website" class="form-control"
+                               value="<?php echo esc_attr(get_user_meta($user_id, 'website', true)); ?>"
+                               placeholder="<?php _e('https://yourwebsite.com', 'mobooking'); ?>">
+                        <p class="field-help"><?php _e('Your business website (optional)', 'mobooking'); ?></p>
+                    </div>
+
+                    <div class="field-group">
+                        <label for="business-description" class="field-label"><?php _e('Business Description', 'mobooking'); ?></label>
+                        <textarea id="business-description" name="business_description" class="form-control" rows="4"
+                                  placeholder="<?php _e('Brief description of your business and services...', 'mobooking'); ?>"><?php echo esc_textarea(get_user_meta($user_id, 'business_description', true)); ?></textarea>
+                        <p class="field-help"><?php _e('A brief description of your business for customer reference', 'mobooking'); ?></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Branding Tab -->
+        <div id="branding" class="tab-pane" role="tabpanel">
+            <div class="settings-section-wrapper">
+                <div class="section-header">
+                    <h2 class="section-title"><?php _e('Branding & Visual Identity', 'mobooking'); ?></h2>
+                    <p class="section-description"><?php _e('Customize the look and feel of your booking forms and communications', 'mobooking'); ?></p>
+                </div>
+
+                <div class="settings-fields">
+                    <!-- Logo Section -->
+                    <div class="branding-section">
+                        <h3 class="subsection-title"><?php _e('Logo & Visual Identity', 'mobooking'); ?></h3>
+
+                        <div class="logo-upload-section">
+                            <div class="logo-preview">
+                                <?php if (!empty($settings->logo_url)) : ?>
+                                    <img src="<?php echo esc_url($settings->logo_url); ?>" alt="<?php _e('Current Logo', 'mobooking'); ?>" class="current-logo">
+                                <?php else : ?>
+                                    <div class="logo-placeholder">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
+                                            <circle cx="9" cy="9" r="2"></circle>
+                                            <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
+                                        </svg>
+                                        <span><?php _e('No Logo Uploaded', 'mobooking'); ?></span>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="logo-upload-controls">
+                                <input type="hidden" id="logo-url" name="logo_url" value="<?php echo esc_attr($settings->logo_url); ?>">
+                                <button type="button" class="btn-secondary select-logo-btn">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                        <polyline points="7,10 12,15 17,10"></polyline>
+                                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                                    </svg>
+                                    <?php _e('Upload Logo', 'mobooking'); ?>
+                                </button>
+
+                                <?php if (!empty($settings->logo_url)) : ?>
+                                    <button type="button" class="btn-secondary remove-logo-btn">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="m3 6 3 18h12l3-18"></path>
+                                            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
+                                        </svg>
+                                        <?php _e('Remove', 'mobooking'); ?>
+                                    </button>
+                                <?php endif; ?>
+                            </div>
+
+                            <p class="field-help"><?php _e('Upload your business logo. Recommended size: 200x80px or similar aspect ratio', 'mobooking'); ?></p>
+                        </div>
+                    </div>
+
+                    <!-- Color Scheme Section -->
+                    <div class="branding-section">
+                        <h3 class="subsection-title"><?php _e('Color Scheme', 'mobooking'); ?></h3>
+
+                        <div class="color-scheme-grid">
+                            <div class="field-group">
+                                <label for="primary-color" class="field-label"><?php _e('Primary Color', 'mobooking'); ?></label>
+                                <div class="color-input-group">
+                                    <input type="color" id="primary-color" name="primary_color"
+                                           value="<?php echo esc_attr($settings->primary_color); ?>" class="color-picker">
+                                    <input type="text" class="color-text" value="<?php echo esc_attr($settings->primary_color); ?>" readonly>
+                                    <div class="color-preview" style="background-color: <?php echo esc_attr($settings->primary_color); ?>"></div>
+                                </div>
+                                <p class="field-help"><?php _e('Main brand color used for buttons and highlights', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="color-presets">
+                                <label class="field-label"><?php _e('Quick Color Presets', 'mobooking'); ?></label>
+                                <div class="preset-colors">
+                                    <button type="button" class="color-preset" data-color="#4CAF50" style="background-color: #4CAF50;" title="Green"></button>
+                                    <button type="button" class="color-preset" data-color="#2196F3" style="background-color: #2196F3;" title="Blue"></button>
+                                    <button type="button" class="color-preset" data-color="#FF9800" style="background-color: #FF9800;" title="Orange"></button>
+                                    <button type="button" class="color-preset" data-color="#9C27B0" style="background-color: #9C27B0;" title="Purple"></button>
+                                    <button type="button" class="color-preset" data-color="#F44336" style="background-color: #F44336;" title="Red"></button>
+                                    <button type="button" class="color-preset" data-color="#607D8B" style="background-color: #607D8B;" title="Blue Grey"></button>
+                                    <button type="button" class="color-preset" data-color="#795548" style="background-color: #795548;" title="Brown"></button>
+                                    <button type="button" class="color-preset" data-color="#000000" style="background-color: #000000;" title="Black"></button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Preview Section -->
+                    <div class="branding-section">
+                        <h3 class="subsection-title"><?php _e('Preview', 'mobooking'); ?></h3>
+
+                        <div class="branding-preview">
+                            <div class="preview-card" style="border-color: <?php echo esc_attr($settings->primary_color); ?>;">
+                                <div class="preview-header" style="background-color: <?php echo esc_attr($settings->primary_color); ?>;">
+                                    <?php if (!empty($settings->logo_url)) : ?>
+                                        <img src="<?php echo esc_url($settings->logo_url); ?>" alt="Logo Preview" class="preview-logo">
+                                    <?php endif; ?>
+                                    <div class="preview-title"><?php echo esc_html($settings->company_name); ?></div>
+                                </div>
+                                <div class="preview-content">
+                                    <p><?php _e('This is how your branding will appear on booking forms and emails.', 'mobooking'); ?></p>
+                                    <button type="button" class="preview-button" style="background-color: <?php echo esc_attr($settings->primary_color); ?>;">
+                                        <?php _e('Book Now', 'mobooking'); ?>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Notifications Tab -->
+        <div id="notifications" class="tab-pane" role="tabpanel">
+            <div class="settings-section-wrapper">
+                <div class="section-header">
+                    <h2 class="section-title"><?php _e('Email Templates & Notifications', 'mobooking'); ?></h2>
+                    <p class="section-description"><?php _e('Customize email templates and notification preferences', 'mobooking'); ?></p>
+                </div>
+
+                <div class="settings-fields">
+                    <!-- Email Templates Section -->
+                    <div class="notification-section">
+                        <h3 class="subsection-title"><?php _e('Email Templates', 'mobooking'); ?></h3>
+
+                        <div class="field-group">
+                            <label for="email-header" class="field-label"><?php _e('Email Header Template', 'mobooking'); ?></label>
+                            <div class="email-template-editor">
+                                <div class="template-toolbar">
+                                    <div class="template-variables">
+                                        <label><?php _e('Available Variables:', 'mobooking'); ?></label>
+                                        <span class="variable-tag" data-variable="{{company_name}}"><?php _e('Company Name', 'mobooking'); ?></span>
+                                        <span class="variable-tag" data-variable="{{current_year}}"><?php _e('Current Year', 'mobooking'); ?></span>
+                                        <span class="variable-tag" data-variable="{{phone}}"><?php _e('Phone', 'mobooking'); ?></span>
+                                        <span class="variable-tag" data-variable="{{email}}"><?php _e('Email', 'mobooking'); ?></span>
+                                    </div>
+                                </div>
+                                <textarea id="email-header" name="email_header" class="form-control email-template" rows="6"><?php echo esc_textarea($settings->email_header); ?></textarea>
+                            </div>
+                            <p class="field-help"><?php _e('HTML template for email headers. Click variable tags to insert them.', 'mobooking'); ?></p>
+                        </div>
+
+                        <div class="field-group">
+                            <label for="email-footer" class="field-label"><?php _e('Email Footer Template', 'mobooking'); ?></label>
+                            <div class="email-template-editor">
+                                <div class="template-toolbar">
+                                    <div class="template-variables">
+                                        <label><?php _e('Available Variables:', 'mobooking'); ?></label>
+                                        <span class="variable-tag" data-variable="{{company_name}}"><?php _e('Company Name', 'mobooking'); ?></span>
+                                        <span class="variable-tag" data-variable="{{current_year}}"><?php _e('Current Year', 'mobooking'); ?></span>
+                                        <span class="variable-tag" data-variable="{{phone}}"><?php _e('Phone', 'mobooking'); ?></span>
+                                        <span class="variable-tag" data-variable="{{email}}"><?php _e('Email', 'mobooking'); ?></span>
+                                    </div>
+                                </div>
+                                <textarea id="email-footer" name="email_footer" class="form-control email-template" rows="6"><?php echo esc_textarea($settings->email_footer); ?></textarea>
+                            </div>
+                            <p class="field-help"><?php _e('HTML template for email footers. Click variable tags to insert them.', 'mobooking'); ?></p>
+                        </div>
+
+                        <div class="field-group">
+                            <label for="booking-confirmation-message" class="field-label"><?php _e('Booking Confirmation Message', 'mobooking'); ?></label>
+                            <textarea id="booking-confirmation-message" name="booking_confirmation_message" class="form-control" rows="4"
+                                      placeholder="<?php _e('Thank you for your booking. We will contact you shortly...', 'mobooking'); ?>"><?php echo esc_textarea($settings->booking_confirmation_message); ?></textarea>
+                            <p class="field-help"><?php _e('Message sent to customers when they make a booking', 'mobooking'); ?></p>
+                        </div>
+                    </div>
+
+                    <!-- Notification Preferences -->
+                    <div class="notification-section">
+                        <h3 class="subsection-title"><?php _e('Notification Preferences', 'mobooking'); ?></h3>
+
+                        <div class="notification-preferences">
+                            <div class="preference-item">
+                                <div class="preference-header">
+                                    <label class="preference-label">
+                                        <input type="checkbox" name="notify_new_booking" value="1"
+                                               <?php checked(get_user_meta($user_id, 'notify_new_booking', true), '1'); ?>>
+                                        <span class="preference-title"><?php _e('New Booking Notifications', 'mobooking'); ?></span>
+                                    </label>
+                                </div>
+                                <p class="preference-description"><?php _e('Receive email notifications when new bookings are made', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="preference-item">
+                                <div class="preference-header">
+                                    <label class="preference-label">
+                                        <input type="checkbox" name="notify_booking_changes" value="1"
+                                               <?php checked(get_user_meta($user_id, 'notify_booking_changes', true), '1'); ?>>
+                                        <span class="preference-title"><?php _e('Booking Changes', 'mobooking'); ?></span>
+                                    </label>
+                                </div>
+                                <p class="preference-description"><?php _e('Get notified when bookings are modified or cancelled', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="preference-item">
+                                <div class="preference-header">
+                                    <label class="preference-label">
+                                        <input type="checkbox" name="notify_reminders" value="1"
+                                               <?php checked(get_user_meta($user_id, 'notify_reminders', true), '1'); ?>>
+                                        <span class="preference-title"><?php _e('Booking Reminders', 'mobooking'); ?></span>
+                                    </label>
+                                </div>
+                                <p class="preference-description"><?php _e('Send reminder emails before scheduled services', 'mobooking'); ?></p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Email Preview -->
+                    <div class="notification-section">
+                        <h3 class="subsection-title"><?php _e('Email Preview', 'mobooking'); ?></h3>
+
+                        <div class="email-preview-container">
+                            <div class="email-preview" id="email-preview">
+                                <div class="email-header-preview">
+                                    <!-- Email header preview will be generated by JavaScript -->
+                                </div>
+                                <div class="email-body-preview">
+                                    <h2><?php _e('Booking Confirmation', 'mobooking'); ?></h2>
+                                    <p><?php _e('Dear Customer,', 'mobooking'); ?></p>
+                                    <div class="email-message-preview">
+                                        <!-- Booking confirmation message preview -->
+                                    </div>
+                                    <p><?php _e('Best regards,', 'mobooking'); ?><br><?php echo esc_html($settings->company_name); ?></p>
+                                </div>
+                                <div class="email-footer-preview">
+                                    <!-- Email footer preview will be generated by JavaScript -->
+                                </div>
+                            </div>
+
+                            <div class="preview-actions">
+                                <button type="button" id="refresh-email-preview" class="btn-secondary">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <polyline points="1 4 1 10 7 10"></polyline>
+                                        <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                                    </svg>
+                                    <?php _e('Refresh Preview', 'mobooking'); ?>
+                                </button>
+
+                                <button type="button" id="send-test-email" class="btn-secondary">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="m3 3 3 9-3 9 19-9Z"></path>
+                                        <path d="m6 12 13 0"></path>
+                                    </svg>
+                                    <?php _e('Send Test Email', 'mobooking'); ?>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Advanced Tab -->
+        <div id="advanced" class="tab-pane" role="tabpanel">
+            <div class="settings-section-wrapper">
+                <div class="section-header">
+                    <h2 class="section-title"><?php _e('Advanced Settings', 'mobooking'); ?></h2>
+                    <p class="section-description"><?php _e('Advanced configuration options and integrations', 'mobooking'); ?></p>
+                </div>
+
+                <div class="settings-fields">
+                    <!-- Terms & Conditions -->
+                    <div class="advanced-section">
+                        <h3 class="subsection-title"><?php _e('Terms & Conditions', 'mobooking'); ?></h3>
+
+                        <div class="field-group">
+                            <label for="terms-conditions" class="field-label"><?php _e('Terms & Conditions Text', 'mobooking'); ?></label>
+                            <textarea id="terms-conditions" name="terms_conditions" class="form-control" rows="8"
+                                      placeholder="<?php _e('Enter your terms and conditions that customers must agree to...', 'mobooking'); ?>"><?php echo esc_textarea($settings->terms_conditions); ?></textarea>
+                            <p class="field-help"><?php _e('Legal terms and conditions that customers must accept when booking', 'mobooking'); ?></p>
+                        </div>
+
+                        <div class="checkbox-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="require_terms_acceptance" value="1"
+                                       <?php checked(get_user_meta($user_id, 'require_terms_acceptance', true), '1'); ?>>
+                                <span class="checkbox-text"><?php _e('Require customers to accept terms & conditions', 'mobooking'); ?></span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <!-- Business Hours -->
+                    <div class="advanced-section">
+                        <h3 class="subsection-title"><?php _e('Business Hours', 'mobooking'); ?></h3>
+
+                        <div class="business-hours-grid">
+                            <?php
+                            $days = array(
+                                'monday' => __('Monday', 'mobooking'),
+                                'tuesday' => __('Tuesday', 'mobooking'),
+                                'wednesday' => __('Wednesday', 'mobooking'),
+                                'thursday' => __('Thursday', 'mobooking'),
+                                'friday' => __('Friday', 'mobooking'),
+                                'saturday' => __('Saturday', 'mobooking'),
+                                'sunday' => __('Sunday', 'mobooking')
+                            );
+
+                            $business_hours = get_user_meta($user_id, 'business_hours', true);
+                            if (!is_array($business_hours)) {
+                                $business_hours = array();
+                            }
+
+                            foreach ($days as $day_key => $day_name) :
+                                $is_open = isset($business_hours[$day_key]['open']) ? $business_hours[$day_key]['open'] : true;
+                                $start_time = isset($business_hours[$day_key]['start']) ? $business_hours[$day_key]['start'] : '09:00';
+                                $end_time = isset($business_hours[$day_key]['end']) ? $business_hours[$day_key]['end'] : '17:00';
+                            ?>
+                                <div class="business-hour-row">
+                                    <div class="day-checkbox">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" name="business_hours[<?php echo $day_key; ?>][open]" value="1"
+                                                   <?php checked($is_open, true); ?> class="day-toggle">
+                                            <span class="day-name"><?php echo esc_html($day_name); ?></span>
+                                        </label>
+                                    </div>
+
+                                    <div class="time-inputs <?php echo $is_open ? '' : 'disabled'; ?>">
+                                        <input type="time" name="business_hours[<?php echo $day_key; ?>][start]"
+                                               value="<?php echo esc_attr($start_time); ?>" class="time-input"
+                                               <?php echo $is_open ? '' : 'disabled'; ?>>
+                                        <span class="time-separator">-</span>
+                                        <input type="time" name="business_hours[<?php echo $day_key; ?>][end]"
+                                               value="<?php echo esc_attr($end_time); ?>" class="time-input"
+                                               <?php echo $is_open ? '' : 'disabled'; ?>>
+                                    </div>
+
+                                    <div class="closed-indicator <?php echo $is_open ? 'hidden' : ''; ?>">
+                                        <span class="closed-text"><?php _e('Closed', 'mobooking'); ?></span>
+                                    </div>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+
+                        <p class="field-help"><?php _e('Set your business operating hours. This affects booking availability.', 'mobooking'); ?></p>
+                    </div>
+
+                    <!-- Booking Settings -->
+                    <div class="advanced-section">
+                        <h3 class="subsection-title"><?php _e('Booking Settings', 'mobooking'); ?></h3>
+
+                        <div class="field-row">
+                            <div class="field-group">
+                                <label for="booking-lead-time" class="field-label"><?php _e('Minimum Lead Time (hours)', 'mobooking'); ?></label>
+                                <input type="number" id="booking-lead-time" name="booking_lead_time" class="form-control"
+                                       min="0" max="168" step="1"
+                                       value="<?php echo esc_attr(get_user_meta($user_id, 'booking_lead_time', true) ?: '24'); ?>">
+                                <p class="field-help"><?php _e('Minimum hours in advance customers must book', 'mobooking'); ?></p>
+                            </div>
+
+                            <div class="field-group">
+                                <label for="max-bookings-per-day" class="field-label"><?php _e('Max Bookings Per Day', 'mobooking'); ?></label>
+                                <input type="number" id="max-bookings-per-day" name="max_bookings_per_day" class="form-control"
+                                       min="1" max="50" step="1"
+                                       value="<?php echo esc_attr(get_user_meta($user_id, 'max_bookings_per_day', true) ?: '10'); ?>">
+                                <p class="field-help"><?php _e('Maximum number of bookings allowed per day', 'mobooking'); ?></p>
+                            </div>
+                        </div>
+
+                        <div class="checkbox-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="auto_confirm_bookings" value="1"
+                                       <?php checked(get_user_meta($user_id, 'auto_confirm_bookings', true), '1'); ?>>
+                                <span class="checkbox-text"><?php _e('Automatically confirm new bookings', 'mobooking'); ?></span>
+                            </label>
+
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="allow_same_day_booking" value="1"
+                                       <?php checked(get_user_meta($user_id, 'allow_same_day_booking', true), '1'); ?>>
+                                <span class="checkbox-text"><?php _e('Allow same-day bookings', 'mobooking'); ?></span>
+                            </label>
+
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="send_booking_reminders" value="1"
+                                       <?php checked(get_user_meta($user_id, 'send_booking_reminders', true), '1'); ?>>
+                                <span class="checkbox-text"><?php _e('Send automatic booking reminders', 'mobooking'); ?></span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <!-- Data Export -->
+                    <div class="advanced-section">
+                        <h3 class="subsection-title"><?php _e('Data Management', 'mobooking'); ?></h3>
+
+                        <div class="data-management-grid">
+                            <div class="data-action-card">
+                                <div class="action-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                        <polyline points="17,8 12,3 7,8"></polyline>
+                                        <line x1="12" y1="3" x2="12" y2="15"></line>
+                                    </svg>
+                                </div>
+                                <div class="action-content">
+                                    <h4><?php _e('Export Data', 'mobooking'); ?></h4>
+                                    <p><?php _e('Export your bookings, customers, and settings data', 'mobooking'); ?></p>
+                                    <button type="button" id="export-data-btn" class="btn-secondary">
+                                        <?php _e('Export All Data', 'mobooking'); ?>
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div class="data-action-card">
+                                <div class="action-icon">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                        <polyline points="7,10 12,15 17,10"></polyline>
+                                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                                    </svg>
+                                </div>
+                                <div class="action-content">
+                                    <h4><?php _e('Import Data', 'mobooking'); ?></h4>
+                                    <p><?php _e('Import customer data from CSV files', 'mobooking'); ?></p>
+                                    <input type="file" id="import-file" accept=".csv" style="display: none;">
+                                    <button type="button" id="import-data-btn" class="btn-secondary">
+                                        <?php _e('Import CSV', 'mobooking'); ?>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- System Information -->
+                    <div class="advanced-section">
+                        <h3 class="subsection-title"><?php _e('System Information', 'mobooking'); ?></h3>
+
+                        <div class="system-info-grid">
+                            <div class="info-item">
+                                <span class="info-label"><?php _e('User ID:', 'mobooking'); ?></span>
+                                <span class="info-value"><?php echo esc_html($user_id); ?></span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label"><?php _e('Account Created:', 'mobooking'); ?></span>
+                                <span class="info-value"><?php echo esc_html(date_i18n(get_option('date_format'), strtotime($user_data->user_registered))); ?></span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label"><?php _e('Total Bookings:', 'mobooking'); ?></span>
+                                <span class="info-value">
+                                    <?php
+                                    $bookings_manager = new \MoBooking\Bookings\Manager();
+                                    echo esc_html($bookings_manager->count_user_bookings($user_id));
+                                    ?>
+                                </span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label"><?php _e('Active Services:', 'mobooking'); ?></span>
+                                <span class="info-value">
+                                    <?php
+                                    $services_manager = new \MoBooking\Services\ServicesManager();
+                                    $services = $services_manager->get_user_services($user_id);
+                                    echo esc_html(count($services));
+                                    ?>
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Form Actions -->
+        <div class="settings-actions">
+            <div class="settings-actions-left">
+                <button type="button" id="restore-defaults-btn" class="btn-secondary">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="1 4 1 10 7 10"></polyline>
+                        <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                    </svg>
+                    <?php _e('Restore Defaults', 'mobooking'); ?>
+                </button>
+            </div>
+
+            <div class="settings-actions-right">
+                <button type="button" id="save-draft-btn" class="btn-secondary">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                        <polyline points="17,21 17,13 7,13 7,21"></polyline>
+                        <polyline points="7,3 7,8 15,8"></polyline>
+                    </svg>
+                    <?php _e('Save Draft', 'mobooking'); ?>
+                </button>
+
+                <button type="submit" id="save-settings-btn" class="btn-primary">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                        <polyline points="17,21 17,13 7,13 7,21"></polyline>
+                        <polyline points="7,3 7,8 15,8"></polyline>
+                    </svg>
+                    <span class="btn-text"><?php _e('Save All Settings', 'mobooking'); ?></span>
+                    <span class="btn-loading"><?php _e('Saving...', 'mobooking'); ?></span>
+                </button>
+            </div>
+        </div>
+    </form>
+</div>
+
+<!-- Preview Modal -->
+<div id="settings-preview-modal" class="mobooking-modal" style="display:none;">
+    <div class="modal-content modal-large">
+        <button class="modal-close" aria-label="<?php _e('Close', 'mobooking'); ?>">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M18 6 6 18M6 6l12 12"/>
+            </svg>
+        </button>
+
+        <div class="modal-header">
+            <h3><?php _e('Settings Preview', 'mobooking'); ?></h3>
+            <div class="preview-tabs">
+                <button type="button" class="preview-tab-btn active" data-preview="branding">
+                    <?php _e('Branding', 'mobooking'); ?>
+                </button>
+                <button type="button" class="preview-tab-btn" data-preview="email">
+                    <?php _e('Email', 'mobooking'); ?>
+                </button>
+            </div>
+        </div>
+
+        <div class="modal-body">
+            <div id="branding-preview" class="preview-content active">
+                <div class="branding-preview-container">
+                    <div class="preview-booking-form">
+                        <!-- Preview content will be generated by JavaScript -->
+                    </div>
+                </div>
+            </div>
+
+            <div id="email-preview-full" class="preview-content">
+                <div class="email-preview-container">
+                    <!-- Email preview content will be generated by JavaScript -->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Confirmation Modal -->
+<div id="settings-confirmation-modal" class="mobooking-modal" style="display:none;">
+    <div class="modal-content">
+        <h3 id="confirmation-title"><?php _e('Confirm Action', 'mobooking'); ?></h3>
+        <p id="confirmation-message"><?php _e('Are you sure you want to perform this action?', 'mobooking'); ?></p>
+
+        <div class="form-actions">
+            <button type="button" class="btn-secondary cancel-confirmation-btn">
+                <?php _e('Cancel', 'mobooking'); ?>
+            </button>
+            <button type="button" class="btn-danger confirm-action-btn">
+                <span class="btn-text"><?php _e('Confirm', 'mobooking'); ?></span>
+                <span class="btn-loading"><?php _e('Processing...', 'mobooking'); ?></span>
+            </button>
+        </div>
+    </div>
+</div>
+
+<script>
+// Settings Management JavaScript
+jQuery(document).ready(function($) {
+    const SettingsManager = {
+        config: {
+            ajaxUrl: '<?php echo admin_url('admin-ajax.php'); ?>',
+            nonce: '<?php echo wp_create_nonce('mobooking-settings-nonce'); ?>',
+            userId: <?php echo $user_id; ?>
+        },
+
+        state: {
+            isProcessing: false,
+            hasUnsavedChanges: false,
+            currentTab: 'business'
+        },
+
+        init: function() {
+            this.attachEventListeners();
+            this.initializeColorPickers();
+            this.initializeTabs();
+            this.trackChanges();
+            this.updateEmailPreview();
+            this.initializeBusinessHours();
+        },
+
+        attachEventListeners: function() {
+            const self = this;
+
+            // Tab switching
+            $('.tab-button').on('click', function() {
+                const tabId = $(this).data('tab');
+                self.switchTab(tabId);
+            });
+
+            // Form submission
+            $('#settings-form').on('submit', function(e) {
+                e.preventDefault();
+                self.saveSettings();
+            });
+
+            // Save draft
+            $('#save-draft-btn').on('click', function() {
+                self.saveSettings(true);
+            });
+
+            // Color presets
+            $('.color-preset').on('click', function() {
+                const color = $(this).data('color');
+                $('#primary-color').val(color).trigger('change');
+            });
+
+            // Color picker sync
+            $('.color-picker').on('input change', function() {
+                const color = $(this).val();
+                $(this).siblings('.color-text').val(color);
+                $(this).siblings('.color-preview').css('background-color', color);
+                self.updateBrandingPreview();
+            });
+
+            // Logo management
+            $('.select-logo-btn').on('click', function() {
+                self.selectLogo();
+            });
+
+            $('.remove-logo-btn').on('click', function() {
+                self.removeLogo();
+            });
+
+            // Email template variables
+            $('.variable-tag').on('click', function() {
+                const variable = $(this).data('variable');
+                const textarea = $(this).closest('.email-template-editor').find('textarea');
+                self.insertVariable(textarea, variable);
+            });
+
+            // Email preview
+            $('#email-header, #email-footer, #booking-confirmation-message').on('input', function() {
+                self.updateEmailPreview();
+            });
+
+            $('#refresh-email-preview').on('click', function() {
+                self.updateEmailPreview();
+            });
+
+            $('#send-test-email').on('click', function() {
+                self.sendTestEmail();
+            });
+
+            // Business hours
+            $('.day-toggle').on('change', function() {
+                self.toggleBusinessHours($(this));
+            });
+
+            // Preview
+            $('#preview-settings-btn').on('click', function() {
+                self.showPreview();
+            });
+
+            // Data management
+            $('#export-data-btn').on('click', function() {
+                self.exportData();
+            });
+
+            $('#import-data-btn').on('click', function() {
+                $('#import-file').click();
+            });
+
+            $('#import-file').on('change', function() {
+                if (this.files.length > 0) {
+                    self.importData(this.files[0]);
+                }
+            });
+
+            // Reset/Restore actions
+            $('#reset-settings-btn, #restore-defaults-btn').on('click', function() {
+                self.showConfirmation(
+                    '<?php _e('Reset Settings', 'mobooking'); ?>',
+                    '<?php _e('Are you sure you want to reset all settings to defaults? This action cannot be undone.', 'mobooking'); ?>',
+                    function() { self.resetSettings(); }
+                );
+            });
+
+            // Modal controls
+            $('.modal-close, .cancel-confirmation-btn').on('click', function() {
+                self.hideModals();
+            });
+
+            $('.confirm-action-btn').on('click', function() {
+                self.executeConfirmedAction();
+            });
+
+            // Preview tabs
+            $('.preview-tab-btn').on('click', function() {
+                const previewType = $(this).data('preview');
+                self.switchPreviewTab(previewType);
+            });
+        },
+
+        initializeColorPickers: function() {
+            // Sync color inputs
+            $('.color-picker').each(function() {
+                const $picker = $(this);
+                const $text = $picker.siblings('.color-text');
+                const $preview = $picker.siblings('.color-preview');
+
+                $picker.on('input', function() {
+                    const color = $(this).val();
+                    $text.val(color);
+                    $preview.css('background-color', color);
+                });
+            });
+        },
+
+        initializeTabs: function() {
+            // Get active tab from URL or default
+            const urlParams = new URLSearchParams(window.location.search);
+            const activeTab = urlParams.get('tab') || 'business';
+            this.switchTab(activeTab);
+        },
+
+        switchTab: function(tabId) {
+            // Update button states
+            $('.tab-button').removeClass('active').attr('aria-selected', 'false');
+            $(`.tab-button[data-tab="${tabId}"]`).addClass('active').attr('aria-selected', 'true');
+
+            // Update tab panes
+            $('.tab-pane').removeClass('active');
+            $(`#${tabId}`).addClass('active');
+
+            // Update URL
+            const url = new URL(window.location);
+            url.searchParams.set('tab', tabId);
+            window.history.replaceState({}, '', url);
+
+            this.state.currentTab = tabId;
+        },
+
+        trackChanges: function() {
+            const self = this;
+            $('#settings-form input, #settings-form textarea, #settings-form select').on('change input', function() {
+                self.state.hasUnsavedChanges = true;
+            });
+
+            // Warn before leaving with unsaved changes
+            $(window).on('beforeunload', function() {
+                if (self.state.hasUnsavedChanges) {
+                    return '<?php _e('You have unsaved changes. Are you sure you want to leave?', 'mobooking'); ?>';
+                }
+            });
+        },
+
+        saveSettings: function(isDraft = false) {
+            if (this.state.isProcessing) return;
+
+            this.state.isProcessing = true;
+            const $btn = isDraft ? $('#save-draft-btn') : $('#save-settings-btn');
+            this.setLoading($btn, true);
+
+            const formData = new FormData($('#settings-form')[0]);
+            formData.append('action', 'mobooking_save_settings');
+            formData.append('is_draft', isDraft ? '1' : '0');
+
+            $.ajax({
+                url: this.config.ajaxUrl,
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: (response) => {
+                    if (response.success) {
+                        this.showNotification(response.data.message || 'Settings saved successfully', 'success');
+                        this.state.hasUnsavedChanges = false;
+                    } else {
+                        this.showNotification(response.data?.message || 'Failed to save settings', 'error');
+                    }
+                },
+                error: () => {
+                    this.showNotification('Error saving settings', 'error');
+                },
+                complete: () => {
+                    this.state.isProcessing = false;
+                    this.setLoading($btn, false);
+                }
+            });
+        },
+
+        selectLogo: function() {
+            if (typeof wp !== 'undefined' && wp.media) {
+                const mediaUploader = wp.media({
+                    title: 'Choose Business Logo',
+                    button: { text: 'Use This Logo' },
+                    multiple: false,
+                    library: { type: 'image' }
+                });
+
+                mediaUploader.on('select', () => {
+                    const attachment = mediaUploader.state().get('selection').first().toJSON();
+                    $('#logo-url').val(attachment.url);
+                    this.updateLogoPreview(attachment.url);
+                    this.updateBrandingPreview();
+                    this.state.hasUnsavedChanges = true;
+                });
+
+                mediaUploader.open();
+            } else {
+                const logoUrl = prompt('Enter logo URL:');
+                if (logoUrl) {
+                    $('#logo-url').val(logoUrl);
+                    this.updateLogoPreview(logoUrl);
+                    this.updateBrandingPreview();
+                    this.state.hasUnsavedChanges = true;
+                }
+            }
+        },
+
+        removeLogo: function() {
+            $('#logo-url').val('');
+            this.updateLogoPreview('');
+            this.updateBrandingPreview();
+            this.state.hasUnsavedChanges = true;
+        },
+
+        updateLogoPreview: function(url) {
+            const $preview = $('.logo-preview');
+            const $removeBtn = $('.remove-logo-btn');
+
+            if (url) {
+                $preview.html(`<img src="${url}" alt="Logo Preview" class="current-logo">`);
+                $removeBtn.show();
+            } else {
+                $preview.html(`
+                    <div class="logo-placeholder">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
+                            <circle cx="9" cy="9" r="2"></circle>
+                            <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
+                        </svg>
+                        <span>No Logo Uploaded</span>
+                    </div>
+                `);
+                $removeBtn.hide();
+            }
+        },
+
+        updateBrandingPreview: function() {
+            const companyName = $('#company-name').val() || 'Your Company';
+            const primaryColor = $('#primary-color').val();
+            const logoUrl = $('#logo-url').val();
+
+            const $preview = $('.branding-preview .preview-card');
+            const $header = $preview.find('.preview-header');
+            const $title = $preview.find('.preview-title');
+            const $button = $preview.find('.preview-button');
+            const $logo = $preview.find('.preview-logo');
+
+            $header.css('background-color', primaryColor);
+            $button.css('background-color', primaryColor);
+            $title.text(companyName);
+            $preview.css('border-color', primaryColor);
+
+            if (logoUrl) {
+                if ($logo.length === 0) {
+                    $header.prepend(`<img src="${logoUrl}" alt="Logo Preview" class="preview-logo">`);
+                } else {
+                    $logo.attr('src', logoUrl);
+                }
+            } else {
+                $logo.remove();
+            }
+        },
+
+        insertVariable: function($textarea, variable) {
+            const textarea = $textarea[0];
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const text = $textarea.val();
+
+            const newText = text.substring(0, start) + variable + text.substring(end);
+            $textarea.val(newText);
+
+            // Set cursor position after the inserted variable
+            const newPosition = start + variable.length;
+            textarea.setSelectionRange(newPosition, newPosition);
+            textarea.focus();
+
+            this.updateEmailPreview();
+            this.state.hasUnsavedChanges = true;
+        },
+
+        updateEmailPreview: function() {
+            const header = $('#email-header').val();
+            const footer = $('#email-footer').val();
+            const message = $('#booking-confirmation-message').val();
+            const companyName = $('#company-name').val() || 'Your Company';
+            const phone = $('#company-phone').val() || '';
+            const email = $('#company-email').val() || '';
+            const currentYear = new Date().getFullYear();
+
+            // Replace variables
+            let processedHeader = header
+                .replace(/\{\{company_name\}\}/g, companyName)
+                .replace(/\{\{phone\}\}/g, phone)
+                .replace(/\{\{email\}\}/g, email)
+                .replace(/\{\{current_year\}\}/g, currentYear);
+
+            let processedFooter = footer
+                .replace(/\{\{company_name\}\}/g, companyName)
+                .replace(/\{\{phone\}\}/g, phone)
+                .replace(/\{\{email\}\}/g, email)
+                .replace(/\{\{current_year\}\}/g, currentYear);
+
+            $('.email-header-preview').html(processedHeader);
+            $('.email-footer-preview').html(processedFooter);
+            $('.email-message-preview').html(`<p>${message}</p>`);
+        },
+
+        sendTestEmail: function() {
+            const $btn = $('#send-test-email');
+            this.setLoading($btn, true);
+
+            const data = {
+                action: 'mobooking_send_test_email',
+                email_header: $('#email-header').val(),
+                email_footer: $('#email-footer').val(),
+                booking_confirmation_message: $('#booking-confirmation-message').val(),
+                company_name: $('#company-name').val(),
+                phone: $('#company-phone').val(),
+                nonce: this.config.nonce
+            };
+
+            $.ajax({
+                url: this.config.ajaxUrl,
+                type: 'POST',
+                data: data,
+                success: (response) => {
+                    if (response.success) {
+                        this.showNotification('Test email sent successfully', 'success');
+                    } else {
+                        this.showNotification(response.data?.message || 'Failed to send test email', 'error');
+                    }
+                },
+                error: () => {
+                    this.showNotification('Error sending test email', 'error');
+                },
+                complete: () => {
+                    this.setLoading($btn, false);
+                }
+            });
+        },
+
+        initializeBusinessHours: function() {
+            const self = this;
+
+            $('.day-toggle').each(function() {
+                self.toggleBusinessHours($(this));
+            });
+        },
+
+        toggleBusinessHours: function($checkbox) {
+            const $row = $checkbox.closest('.business-hour-row');
+            const $timeInputs = $row.find('.time-inputs');
+            const $inputs = $row.find('.time-input');
+            const $closedIndicator = $row.find('.closed-indicator');
+
+            if ($checkbox.is(':checked')) {
+                $timeInputs.removeClass('disabled');
+                $inputs.prop('disabled', false);
+                $closedIndicator.addClass('hidden');
+            } else {
+                $timeInputs.addClass('disabled');
+                $inputs.prop('disabled', true);
+                $closedIndicator.removeClass('hidden');
+            }
+        },
+
+        showPreview: function() {
+            this.updateBrandingPreview();
+            this.updateEmailPreview();
+            $('#settings-preview-modal').fadeIn(300);
+            $('body').addClass('modal-open');
+        },
+
+        switchPreviewTab: function(previewType) {
+            $('.preview-tab-btn').removeClass('active');
+            $(`.preview-tab-btn[data-preview="${previewType}"]`).addClass('active');
+
+            $('.preview-content').removeClass('active');
+            $(`#${previewType}-preview, #${previewType}-preview-full`).addClass('active');
+        },
+
+        exportData: function() {
+            const $btn = $('#export-data-btn');
+            this.setLoading($btn, true);
+
+            const data = {
+                action: 'mobooking_export_data',
+                nonce: this.config.nonce
+            };
+
+            $.ajax({
+                url: this.config.ajaxUrl,
+                type: 'POST',
+                data: data,
+                success: (response) => {
+                    if (response.success) {
+                        // Create download link
+                        const blob = new Blob([JSON.stringify(response.data, null, 2)],
+                            { type: 'application/json' });
+                        const url = URL.createObjectURL(blob);
+                        const link = document.createElement('a');
+                        link.href = url;
+                        link.download = `mobooking-export-${new Date().toISOString().split('T')[0]}.json`;
+                        link.click();
+                        URL.revokeObjectURL(url);
+
+                        this.showNotification('Data exported successfully', 'success');
+                    } else {
+                        this.showNotification('Failed to export data', 'error');
+                    }
+                },
+                error: () => {
+                    this.showNotification('Error exporting data', 'error');
+                },
+                complete: () => {
+                    this.setLoading($btn, false);
+                }
+            });
+        },
+
+        importData: function(file) {
+            const $btn = $('#import-data-btn');
+            this.setLoading($btn, true);
+
+            const formData = new FormData();
+            formData.append('action', 'mobooking_import_data');
+            formData.append('import_file', file);
+            formData.append('nonce', this.config.nonce);
+
+            $.ajax({
+                url: this.config.ajaxUrl,
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: (response) => {
+                    if (response.success) {
+                        this.showNotification(response.data.message || 'Data imported successfully', 'success');
+                    } else {
+                        this.showNotification(response.data?.message || 'Failed to import data', 'error');
+                    }
+                },
+                error: () => {
+                    this.showNotification('Error importing data', 'error');
+                },
+                complete: () => {
+                    this.setLoading($btn, false);
+                    $('#import-file').val(''); // Clear file input
+                }
+            });
+        },
+
+        resetSettings: function() {
+            const data = {
+                action: 'mobooking_reset_settings',
+                nonce: this.config.nonce
+            };
+
+            $.ajax({
+                url: this.config.ajaxUrl,
+                type: 'POST',
+                data: data,
+                success: (response) => {
+                    if (response.success) {
+                        this.showNotification('Settings reset successfully', 'success');
+                        setTimeout(() => location.reload(), 1500);
+                    } else {
+                        this.showNotification('Failed to reset settings', 'error');
+                    }
+                },
+                error: () => {
+                    this.showNotification('Error resetting settings', 'error');
+                }
+            });
+        },
+
+        showConfirmation: function(title, message, callback) {
+            $('#confirmation-title').text(title);
+            $('#confirmation-message').text(message);
+            this.confirmedAction = callback;
+            $('#settings-confirmation-modal').fadeIn(300);
+            $('body').addClass('modal-open');
+        },
+
+        executeConfirmedAction: function() {
+            if (typeof this.confirmedAction === 'function') {
+                this.confirmedAction();
+            }
+            this.hideModals();
+        },
+
+        hideModals: function() {
+            $('.mobooking-modal').fadeOut(300);
+            $('body').removeClass('modal-open');
+        },
+
+        setLoading: function($btn, loading) {
+            if (loading) {
+                $btn.addClass('loading').prop('disabled', true);
+            } else {
+                $btn.removeClass('loading').prop('disabled', false);
+            }
+        },
+
+        showNotification: function(message, type = 'info') {
+            $('.notification').remove();
+
+            const colors = {
+                success: '#22c55e',
+                error: '#ef4444',
+                warning: '#f59e0b',
+                info: '#3b82f6',
+            };
+
+            const notification = $(`
+                <div class="notification notification-${type}" style="
+                    position: fixed; top: 24px; right: 24px; z-index: 1000;
+                    padding: 16px 20px; border-radius: 8px;
+                    background: ${colors[type]}; color: white;
+                    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+                    font-weight: 500; max-width: 400px;
+                    animation: slideIn 0.3s ease;
+                ">${message}</div>
+            `);
+
+            $('body').append(notification);
+
+            setTimeout(() => {
+                notification.fadeOut(300, function() {
+                    $(this).remove();
+                });
+            }, 4000);
+        }
+    };
+
+    SettingsManager.init();
+});
+</script>
+
+<style>
+/* Settings Section Styles */
+.settings-section {
+    animation: fadeIn 0.4s ease-out;
+}
+
+.settings-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.settings-header-content {
+    display: flex;
+    align-items: flex-start;
+    gap: 3rem;
+    flex: 1;
+}
+
+.settings-title-group {
+    flex: 1;
+}
+
+.settings-main-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 0.5rem 0;
+    font-size: 22px;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
+.title-icon {
+    width: 25px;
+    height: 25px;
+    color: hsl(var(--primary));
+}
+
+.settings-subtitle {
+    margin: 0;
+    color: hsl(var(--muted-foreground));
+    font-size: 1rem;
+}
+
+.settings-status {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: hsl(var(--accent));
+    border-radius: var(--radius);
+}
+
+.status-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: hsl(var(--muted-foreground));
+}
+
+.status-dot.active {
+    background: hsl(var(--success));
+}
+
+.settings-header-actions {
+    display: flex;
+    gap: 1rem;
+}
+
+/* Settings Tabs */
+.settings-tabs {
+    margin-bottom: 2rem;
+}
+
+
+.tab-button {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius);
+    color: hsl(var(--muted-foreground));
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex: 1;
+    justify-content: center;
+}
+
+.tab-button:hover {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+}
+
+.tab-button.active {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.tab-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+/* Settings Form */
+
+.tab-pane {
+    display: none;
+    padding: 2rem;
+}
+
+.tab-pane.active {
+    display: block;
+    animation: fadeInTab 0.3s ease;
+}
+
+.settings-section-wrapper {
+    max-width: none;
+}
+
+.section-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.section-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.section-description {
+    margin: 0;
+    color: hsl(var(--muted-foreground));
+}
+
+.settings-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.field-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.field-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.field-label {
+    font-weight: 600;
+    color: hsl(var(--foreground));
+    font-size: 0.875rem;
+}
+
+.field-label.required::after {
+    content: ' *';
+    color: hsl(var(--destructive));
+}
+
+.form-control {
+    padding: 0.75rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-size: 0.875rem;
+    transition: border-color 0.2s ease;
+}
+
+.form-control:focus {
+    outline: none;
+    border-color: hsl(var(--primary));
+    box-shadow: 0 0 0 3px hsl(var(--primary) / 0.1);
+}
+
+.field-help {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    margin: 0;
+    line-height: 1.4;
+}
+
+/* Branding Section */
+.branding-section {
+    padding: 1.5rem 0;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.branding-section:last-child {
+    border-bottom: none;
+}
+
+.subsection-title {
+    margin: 0 0 1.5rem 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+.logo-upload-section {
+    display: flex;
+    gap: 2rem;
+    align-items: flex-start;
+}
+
+.logo-preview {
+    width: 200px;
+    height: 100px;
+    border: 2px dashed hsl(var(--border));
+    border-radius: var(--radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: hsl(var(--muted) / 0.3);
+}
+
+.current-logo {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.logo-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    text-align: center;
+}
+
+.logo-placeholder svg {
+    width: 2rem;
+    height: 2rem;
+}
+
+.logo-upload-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    flex: 1;
+}
+
+.color-scheme-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: start;
+}
+
+.color-input-group {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.color-picker {
+    width: 3rem;
+    height: 2.5rem;
+    padding: 0;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    cursor: pointer;
+    background: none;
+}
+
+.color-text {
+    flex: 1;
+    font-family: monospace;
+    font-size: 0.875rem;
+}
+
+.color-preview {
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+}
+
+.preset-colors {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.color-preset {
+    width: 2rem;
+    height: 2rem;
+    border: 2px solid transparent;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.color-preset:hover {
+    border-color: hsl(var(--foreground));
+    transform: scale(1.1);
+}
+
+.branding-preview {
+    margin-top: 1rem;
+}
+
+.preview-card {
+    max-width: 400px;
+    border: 2px solid hsl(var(--primary));
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: hsl(var(--background));
+}
+
+.preview-header {
+    padding: 1rem;
+    background: hsl(var(--primary));
+    color: white;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.preview-logo {
+    height: 2rem;
+    width: auto;
+}
+
+.preview-title {
+    font-weight: 600;
+    font-size: 1.125rem;
+}
+
+.preview-content {
+    padding: 1.5rem;
+}
+
+.preview-button {
+    background: hsl(var(--primary));
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--radius);
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 1rem;
+}
+
+/* Email Templates */
+.notification-section {
+    padding: 1.5rem 0;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.notification-section:last-child {
+    border-bottom: none;
+}
+
+.email-template-editor {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.template-toolbar {
+    background: hsl(var(--muted));
+    padding: 1rem;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.template-variables {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.template-variables label {
+    font-weight: 600;
+    margin-right: 0.5rem;
+}
+
+.variable-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    background: hsl(var(--primary));
+    color: white;
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.variable-tag:hover {
+    background: hsl(var(--primary) / 0.8);
+}
+
+.email-template {
+    border: none;
+    border-radius: 0;
+    font-family: monospace;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    min-height: 120px;
+    resize: vertical;
+}
+
+.notification-preferences {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.preference-item {
+    padding: 1rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    background: hsl(var(--background));
+}
+
+.preference-header {
+    margin-bottom: 0.5rem;
+}
+
+.preference-label {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.preference-title {
+    color: hsl(var(--foreground));
+}
+
+.preference-description {
+    margin: 0;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.875rem;
+}
+
+.email-preview-container {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-top: 1rem;
+}
+
+.email-preview {
+    background: white;
+    color: #333;
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+}
+
+.email-header-preview,
+.email-footer-preview {
+    padding: 1rem;
+}
+
+.email-body-preview {
+    padding: 2rem;
+    min-height: 200px;
+}
+
+.preview-actions {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1rem;
+    justify-content: flex-end;
+}
+
+/* Business Hours */
+.business-hours-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.business-hour-row {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+}
+
+.day-checkbox {
+    display: flex;
+    align-items: center;
+}
+
+.day-name {
+    font-weight: 500;
+    min-width: 100px;
+}
+
+.time-inputs {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: opacity 0.2s ease;
+}
+
+.time-inputs.disabled {
+    opacity: 0.5;
+}
+
+.time-input {
+    padding: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+}
+
+.time-separator {
+    color: hsl(var(--muted-foreground));
+    font-weight: 500;
+}
+
+.closed-indicator {
+    text-align: center;
+}
+
+.closed-text {
+    color: hsl(var(--muted-foreground));
+    font-style: italic;
+}
+
+.hidden {
+    display: none;
+}
+
+/* Advanced Sections */
+.advanced-section {
+    padding: 1.5rem 0;
+    border-bottom: 1px solid hsl(var(--border));
+}
+
+.advanced-section:last-child {
+    border-bottom: none;
+}
+
+.checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+}
+
+.checkbox-text {
+    color: hsl(var(--foreground));
+}
+
+.data-management-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.data-action-card {
+    display: flex;
+    gap: 1rem;
+    padding: 1.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    background: hsl(var(--background));
+}
+
+.action-icon {
+    width: 3rem;
+    height: 3rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: hsl(var(--primary) / 0.1);
+    border-radius: var(--radius);
+    color: hsl(var(--primary));
+    flex-shrink: 0;
+}
+
+.action-content h4 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.action-content p {
+    margin: 0 0 1rem 0;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.875rem;
+}
+
+.system-info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.info-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem;
+    background: hsl(var(--muted) / 0.3);
+    border-radius: var(--radius);
+}
+
+.info-label {
+    font-weight: 500;
+    color: hsl(var(--muted-foreground));
+}
+
+.info-value {
+    font-weight: 600;
+    color: hsl(var(--foreground));
+}
+
+/* Form Actions */
+.settings-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem 2rem;
+    background: hsl(var(--muted) / 0.3);
+    border-top: 1px solid hsl(var(--border));
+}
+
+.settings-actions-left,
+.settings-actions-right {
+    display: flex;
+    gap: 1rem;
+}
+
+/* Responsive Design */
+@media (max-width: 1024px) {
+    .settings-header {
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .settings-header-content {
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .tab-list {
+        flex-direction: column;
+    }
+
+    .tab-button {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .field-row {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .color-scheme-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .data-management-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .system-info-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .business-hour-row {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+    }
+
+    .logo-upload-section {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .settings-actions {
+        flex-direction: column-reverse;
+        gap: 1rem;
+    }
+
+    .settings-actions-left,
+    .settings-actions-right {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+/* Animation keyframes */
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes fadeInTab {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+/* Loading states */
+.loading .btn-text {
+    display: none;
+}
+
+.loading .btn-loading {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.loading .btn-loading::before {
+    content: "";
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    border-top-color: white;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+    .tab-button.active {
+        border: 2px solid hsl(var(--primary));
+    }
+
+    .color-preset:hover {
+        border-width: 3px;
+    }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+/* Print styles */
+@media print {
+    .settings-header-actions,
+    .settings-actions,
+    .preview-actions {
+        display: none;
+    }
+
+    .tab-list {
+        display: none;
+    }
+
+    .tab-pane {
+        display: block !important;
+    }
+}
+</style>
+
+<?php
+// Enqueue additional scripts and styles for settings
+wp_enqueue_media(); // Enable WordPress media uploader
+wp_enqueue_script('wp-color-picker');
+wp_enqueue_style('wp-color-picker');
+
+// Add any additional PHP logic here if needed
+?>

--- a/page-single-booking.php
+++ b/page-single-booking.php
@@ -1,0 +1,1563 @@
+<?php
+// dashboard/sections/single-booking.php - Individual Booking Detail Page
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Get booking details
+$booking = $bookings_manager->get_booking($booking_id, $user_id);
+
+if (!$booking) {
+    ?>
+    <div class="booking-not-found">
+        <div class="not-found-icon">
+            <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <circle cx="12" cy="12" r="10"/>
+                <path d="M15 9l-6 6M9 9l6 6"/>
+            </svg>
+        </div>
+        <h2><?php _e('Booking Not Found', 'mobooking'); ?></h2>
+        <p><?php _e('The booking you\'re looking for doesn\'t exist or you don\'t have permission to view it.', 'mobooking'); ?></p>
+        <a href="<?php echo esc_url(remove_query_arg(array('view', 'booking_id'))); ?>" class="btn-primary">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M15 18l-6-6 6-6"/>
+            </svg>
+            <?php _e('Back to Bookings', 'mobooking'); ?>
+        </a>
+    </div>
+    <?php
+    return;
+}
+
+// Get services data
+$services_manager = new \MoBooking\Services\ServicesManager();
+$services_data     = $booking->services;
+$services_list     = array();
+
+if (is_array($services_data)) {
+    foreach ($services_data as $service_id) {
+        $service = $services_manager->get_service($service_id);
+        if ($service) {
+            $services_list[] = $service;
+        }
+    }
+}
+
+// Parse service options
+$service_options_data = $booking->service_options;
+
+// Date calculations
+$service_date = new DateTime($booking->service_date);
+$created_date = new DateTime($booking->created_at);
+$updated_date = new DateTime($booking->updated_at);
+$now          = new DateTime();
+
+// Calculate time until service
+$interval   = $now->diff($service_date);
+$days_until = $interval->days;
+$is_future  = $service_date > $now;
+$is_today   = $service_date->format('Y-m-d') === $now->format('Y-m-d');
+$is_overdue = $service_date < $now && !in_array($booking->status, ['completed', 'cancelled']);
+
+// Determine urgency
+$urgency_class = '';
+$urgency_text  = '';
+if ($booking->status !== 'completed' && $booking->status !== 'cancelled') {
+    if ($is_overdue) {
+        $urgency_class = 'overdue';
+        $urgency_text  = __('Overdue', 'mobooking');
+    } elseif ($is_today) {
+        $urgency_class = 'today';
+        $urgency_text  = __('Today', 'mobooking');
+    } elseif ($days_until == 1) {
+        $urgency_class = 'tomorrow';
+        $urgency_text  = __('Tomorrow', 'mobooking');
+    } elseif ($days_until <= 3 && $is_future) {
+        $urgency_class = 'soon';
+        $urgency_text  = sprintf(__('In %d days', 'mobooking'), $days_until);
+    }
+}
+?>
+
+<div class="single-booking-page">
+    <!-- Header -->
+    <div class="single-booking-header">
+        <div class="header-navigation">
+            <a href="<?php echo esc_url(remove_query_arg(array('view', 'booking_id'))); ?>" class="back-link">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M15 18l-6-6 6-6"/>
+                </svg>
+                <?php _e('Back to Bookings', 'mobooking'); ?>
+            </a>
+        </div>
+
+        <div class="header-content">
+            <div class="header-main">
+                <div class="booking-id-section">
+                    <h1 class="booking-title">
+                        <?php _e('Booking', 'mobooking'); ?> <span class="booking-id-highlight">#<?php echo $booking->id; ?></span>
+                    </h1>
+                    <div class="booking-meta">
+                        <span class="created-date">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="10"/>
+                                <polyline points="12,6 12,12 16,14"/>
+                            </svg>
+                            <?php printf(__('Created %s', 'mobooking'), $created_date->format('M j, Y \a\t g:i A')); ?>
+                        </span>
+                        <?php if ($updated_date != $created_date) : ?>
+                            <span class="updated-date">
+                                <?php printf(__('Updated %s', 'mobooking'), $updated_date->format('M j, Y \a\t g:i A')); ?>
+                            </span>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <div class="status-section">
+                    <div class="current-status">
+                        <span class="status-badge status-<?php echo esc_attr($booking->status); ?>">
+                            <?php
+                            switch ($booking->status) {
+                                case 'pending':
+                                    echo '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12,6 12,12 16,14"/></svg>';
+                                    _e('Pending Review', 'mobooking');
+                                    break;
+                                case 'confirmed':
+                                    echo '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22,4 12,14.01 9,11.01"/></svg>';
+                                    _e('Confirmed', 'mobooking');
+                                    break;
+                                case 'completed':
+                                    echo '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/></svg>';
+                                    _e('Completed', 'mobooking');
+                                    break;
+                                case 'cancelled':
+                                    echo '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg>';
+                                    _e('Cancelled', 'mobooking');
+                                    break;
+                            }
+                            ?>
+                        </span>
+                    </div>
+
+                    <?php if ($urgency_text) : ?>
+                        <div class="urgency-badge <?php echo $urgency_class; ?>">
+                            <?php echo $urgency_text; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- Quick Actions -->
+            <div class="header-actions">
+                <div class="status-update-dropdown" style="margin-right: 0.75rem;">
+                    <label for="booking-status-changer" class="sr-only"><?php _e('Change Booking Status', 'mobooking'); ?></label>
+                    <select id="booking-status-changer" class="form-control" data-booking-id="<?php echo esc_attr($booking->id); ?>" data-current-status="<?php echo esc_attr($booking->status); ?>" style="padding: 0.75rem 1.25rem; border: 1px solid hsl(var(--border)); border-radius: 8px; font-size: 0.875rem; font-weight: 500; cursor: pointer;">
+                        <option value="pending" <?php selected($booking->status, 'pending'); ?>><?php _e('Pending Review', 'mobooking'); ?></option>
+                        <option value="confirmed" <?php selected($booking->status, 'confirmed'); ?>><?php _e('Confirmed', 'mobooking'); ?></option>
+                        <option value="completed" <?php selected($booking->status, 'completed'); ?>><?php _e('Completed', 'mobooking'); ?></option>
+                        <option value="cancelled" <?php selected($booking->status, 'cancelled'); ?>><?php _e('Cancelled', 'mobooking'); ?></option>
+                    </select>
+                </div>
+                <button type="button" class="btn-secondary" onclick="window.print()">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="6,9 6,2 18,2 18,9"/>
+                        <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
+                        <rect x="6" y="14" width="12" height="8"/>
+                    </svg>
+                    <?php _e('Print', 'mobooking'); ?>
+                </button>
+                <a href="download-booking-pdf.php?booking_id=<?php echo $booking->id; ?>" class="btn-secondary">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                        <polyline points="7 10 12 15 17 10"/>
+                        <line x1="12" y1="15" x2="12" y2="3"/>
+                    </svg>
+                    <?php _e('Download PDF', 'mobooking'); ?>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Main Content -->
+    <div class="single-booking-content">
+        <div class="booking-details-grid">
+            <!-- Customer Information -->
+            <div class="detail-card customer-card">
+                <div class="card-header">
+                    <h2 class="card-title">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+                            <circle cx="12" cy="7" r="4"/>
+                        </svg>
+                        <?php _e('Customer Information', 'mobooking'); ?>
+                    </h2>
+                </div>
+                <div class="card-content">
+                    <div class="customer-profile">
+                        <div class="customer-avatar-large">
+                            <?php echo strtoupper(substr($booking->customer_name, 0, 2)); ?>
+                        </div>
+                        <div class="customer-info">
+                            <h3 class="customer-name"><?php echo esc_html($booking->customer_name); ?></h3>
+                            <div class="contact-details">
+                                <div class="contact-item">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
+                                        <polyline points="22,6 12,13 2,6"/>
+                                    </svg>
+                                    <a href="mailto:<?php echo esc_attr($booking->customer_email); ?>" class="contact-link">
+                                        <?php echo esc_html($booking->customer_email); ?>
+                                    </a>
+                                </div>
+                                <?php if (!empty($booking->customer_phone)) : ?>
+                                    <div class="contact-item">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+                                        </svg>
+                                        <a href="tel:<?php echo esc_attr($booking->customer_phone); ?>" class="contact-link">
+                                            <?php echo esc_html($booking->customer_phone); ?>
+                                        </a>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Service Date & Time -->
+            <div class="detail-card datetime-card">
+                <div class="card-header">
+                    <h2 class="card-title">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16 2V6M8 2V6M3 10H21"/>
+                            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                        </svg>
+                        <?php _e('Service Schedule', 'mobooking'); ?>
+                    </h2>
+                </div>
+                <div class="card-content">
+                    <div class="datetime-display">
+                        <div class="date-section">
+                            <div class="date-main">
+                                <?php echo $service_date->format('l'); ?>
+                            </div>
+                            <div class="date-full">
+                                <?php echo $service_date->format('F j, Y'); ?>
+                            </div>
+                        </div>
+                        <div class="time-section">
+                            <div class="time-main">
+                                <?php echo $service_date->format('g:i A'); ?>
+                            </div>
+                            <div class="timezone">
+                                <?php echo $service_date->format('T'); ?>
+                            </div>
+                        </div>
+                    </div>
+
+                    <?php if ($is_future) : ?>
+                        <div class="countdown">
+                            <div class="countdown-label"><?php _e('Time until service:', 'mobooking'); ?></div>
+                            <div class="countdown-value">
+                                <?php
+                                if ($days_until > 0) {
+                                    printf(_n('%d day', '%d days', $days_until, 'mobooking'), $days_until);
+                                    if ($interval->h > 0) {
+                                        echo ', ' . sprintf(_n('%d hour', '%d hours', $interval->h, 'mobooking'), $interval->h);
+                                    }
+                                } elseif ($interval->h > 0) {
+                                    printf(_n('%d hour', '%d hours', $interval->h, 'mobooking'), $interval->h);
+                                    if ($interval->i > 0) {
+                                        echo ', ' . sprintf(_n('%d minute', '%d minutes', $interval->i, 'mobooking'), $interval->i);
+                                    }
+                                } else {
+                                    printf(_n('%d minute', '%d minutes', $interval->i, 'mobooking'), $interval->i);
+                                }
+                                ?>
+                            </div>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- Service Address -->
+            <div class="detail-card address-card">
+                <div class="card-header">
+                    <h2 class="card-title">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                            <circle cx="12" cy="10" r="3"/>
+                        </svg>
+                        <?php _e('Service Address', 'mobooking'); ?>
+                    </h2>
+                </div>
+                <div class="card-content">
+                    <div class="address-display">
+                        <div class="address-text">
+                            <?php echo nl2br(esc_html($booking->customer_address)); ?>
+                        </div>
+                        <div class="zip-code">
+                            <span class="zip-label"><?php _e('ZIP Code:', 'mobooking'); ?></span>
+                            <span class="zip-value"><?php echo esc_html($booking->zip_code); ?></span>
+                        </div>
+                    </div>
+
+                    <div class="address-actions">
+                        <a href="https://maps.google.com/?q=<?php echo urlencode($booking->customer_address . ', ' . $booking->zip_code); ?>"
+                           target="_blank" rel="noopener" class="map-link">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                                <circle cx="12" cy="10" r="3"/>
+                            </svg>
+                            <?php _e('View on Map', 'mobooking'); ?>
+                        </a>
+
+                        <a href="https://www.google.com/maps/dir/Current+Location/<?php echo urlencode($booking->customer_address . ', ' . $booking->zip_code); ?>"
+                           target="_blank" rel="noopener" class="directions-link">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polygon points="3 11 22 2 13 21 11 13 3 11"/>
+                            </svg>
+                            <?php _e('Get Directions', 'mobooking'); ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Services & Pricing -->
+            <div class="detail-card services-card">
+                <div class="card-header">
+                    <h2 class="card-title">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16.5 9.40002L7.5 4.21002M3.27 6.96002L12 12.01L20.73 6.96002M12 22.08V12"/>
+                        </svg>
+                        <?php _e('Services & Pricing', 'mobooking'); ?>
+                    </h2>
+                </div>
+                <div class="card-content">
+                    <div class="services-list">
+                        <?php if (!empty($services_list)) : ?>
+                            <?php foreach ($services_list as $service) : ?>
+                                <div class="service-item">
+                                    <div class="service-info">
+                                        <div class="service-main">
+                                            <h4 class="service-name"><?php echo esc_html($service->name); ?></h4>
+                                            <?php if (!empty($service->description)) : ?>
+                                                <p class="service-description"><?php echo esc_html($service->description); ?></p>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div class="service-meta">
+                                            <span class="service-duration">
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <circle cx="12" cy="12" r="10"/>
+                                                    <polyline points="12,6 12,12 16,14"/>
+                                                </svg>
+                                                <?php echo sprintf(_n('%d min', '%d mins', $service->duration, 'mobooking'), $service->duration); ?>
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div class="service-price">
+                                        <?php echo function_exists('wc_price') ? wc_price($service->price) : number_format($service->price, 2); ?>
+                                    </div>
+                                </div>
+
+                                <?php if (!empty($service_options_data[$service->id])) : ?>
+                                    <div class="service-options">
+                                        <h5 class="options-title"><?php _e('Selected Options:', 'mobooking'); ?></h5>
+                                        <?php foreach ($service_options_data[$service->id] as $option_id => $option_value) : ?>
+                                            <?php if (!empty($option_value) && $option_value !== '0') : ?>
+                                                <?php
+                                                // Get option details (you might want to create a method to get option by ID)
+                                                $option_name   = sprintf(__('Option %d', 'mobooking'), $option_id);
+                                                $display_value = $option_value;
+
+                                                // Format display value based on option type
+                                                if ($option_value === '1') {
+                                                    $display_value = __('Yes', 'mobooking');
+                                                }
+                                                ?>
+                                                <div class="option-item">
+                                                    <span class="option-name"><?php echo esc_html($option_name); ?>:</span>
+                                                    <span class="option-value"><?php echo esc_html($display_value); ?></span>
+                                                </div>
+                                            <?php endif; ?>
+                                        <?php endforeach; ?>
+                                    </div>
+                                <?php endif; ?>
+                            <?php endforeach; ?>
+                        <?php else : ?>
+                            <div class="no-services">
+                                <p><?php _e('No services specified for this booking.', 'mobooking'); ?></p>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+
+                    <!-- Pricing Summary -->
+                    <div class="pricing-summary">
+                        <div class="pricing-line">
+                            <span class="label"><?php _e('Subtotal:', 'mobooking'); ?></span>
+                            <span class="amount">
+                                <?php
+                                $subtotal = $booking->total_price + $booking->discount_amount;
+                                echo function_exists('wc_price') ? wc_price($subtotal) : number_format($subtotal, 2);
+                                ?>
+                            </span>
+                        </div>
+
+                        <?php if ($booking->discount_amount > 0) : ?>
+                            <div class="pricing-line discount">
+                                <span class="label">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M19 5L5 19M9 6.5C9 7.88071 7.88071 9 6.5 9C5.11929 9 4 7.88071 4 6.5C4 5.11929 5.11929 4 6.5 4C7.88071 4 9 5.11929 9 6.5ZM20 17.5C20 18.8807 18.8807 20 17.5 20C16.1193 20 15 18.8807 15 17.5C15 16.1193 16.1193 15 17.5 15C18.8807 15 20 16.1193 20 17.5Z"/>
+                                    </svg>
+                                    <?php _e('Discount:', 'mobooking'); ?>
+                                    <?php if (!empty($booking->discount_code)) : ?>
+                                        <span class="discount-code">(<?php echo esc_html($booking->discount_code); ?>)</span>
+                                    <?php endif; ?>
+                                </span>
+                                <span class="amount discount-amount">
+                                    -<?php echo function_exists('wc_price') ? wc_price($booking->discount_amount) : number_format($booking->discount_amount, 2); ?>
+                                </span>
+                            </div>
+                        <?php endif; ?>
+
+                        <div class="pricing-line total">
+                            <span class="label"><?php _e('Total:', 'mobooking'); ?></span>
+                            <span class="amount total-amount">
+                                <?php echo function_exists('wc_price') ? wc_price($booking->total_price) : number_format($booking->total_price, 2); ?>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Special Instructions -->
+            <?php if (!empty($booking->notes)) : ?>
+                <div class="detail-card notes-card">
+                    <div class="card-header">
+                        <h2 class="card-title">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                                <polyline points="14,2 14,8 20,8"/>
+                                <line x1="16" y1="13" x2="8" y2="13"/>
+                                <line x1="16" y1="17" x2="8" y2="17"/>
+                                <polyline points="10,9 9,9 8,9"/>
+                            </svg>
+                            <?php _e('Special Instructions', 'mobooking'); ?>
+                        </h2>
+                    </div>
+                    <div class="card-content">
+                        <div class="notes-content">
+                            <?php echo nl2br(esc_html($booking->notes)); ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endif; ?>
+
+            <!-- Booking Timeline -->
+            <div class="detail-card timeline-card">
+                <div class="card-header">
+                    <h2 class="card-title">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="10"/>
+                            <polyline points="12,6 12,12 16,14"/>
+                        </svg>
+                        <?php _e('Booking Timeline', 'mobooking'); ?>
+                    </h2>
+                </div>
+                <div class="card-content">
+                    <div class="timeline">
+                        <div class="timeline-item completed">
+                            <div class="timeline-marker">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                                </svg>
+                            </div>
+                            <div class="timeline-content">
+                                <div class="timeline-title"><?php _e('Booking Created', 'mobooking'); ?></div>
+                                <div class="timeline-time"><?php echo $created_date->format('M j, Y \a\t g:i A'); ?></div>
+                                <div class="timeline-description"><?php _e('Customer submitted booking request', 'mobooking'); ?></div>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item <?php echo in_array($booking->status, ['confirmed', 'completed']) ? 'completed' : 'pending'; ?>">
+                            <div class="timeline-marker">
+                                <?php if (in_array($booking->status, ['confirmed', 'completed'])) : ?>
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                                    </svg>
+                                <?php else : ?>
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="12" cy="12" r="10"/>
+                                        <polyline points="12,6 12,12 16,14"/>
+                                    </svg>
+                                <?php endif; ?>
+                            </div>
+                            <div class="timeline-content">
+                                <div class="timeline-title">
+                                    <?php echo $booking->status === 'confirmed' || $booking->status === 'completed' ?
+                                        __('Booking Confirmed', 'mobooking') : __('Awaiting Confirmation', 'mobooking'); ?>
+                                </div>
+                                <?php if ($booking->status === 'confirmed' || $booking->status === 'completed') : ?>
+                                    <div class="timeline-time"><?php echo $updated_date->format('M j, Y \a\t g:i A'); ?></div>
+                                    <div class="timeline-description"><?php _e('Booking has been confirmed and scheduled', 'mobooking'); ?></div>
+                                <?php else : ?>
+                                    <div class="timeline-description pending-text"><?php _e('Waiting for your confirmation', 'mobooking'); ?></div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item <?php echo $booking->status === 'completed' ? 'completed' : 'future'; ?>">
+                            <div class="timeline-marker">
+                                <?php if ($booking->status === 'completed') : ?>
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2ZM8 12l2 2 4-4"/>
+                                    </svg>
+                                <?php else : ?>
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="12" cy="12" r="10"/>
+                                    </svg>
+                                <?php endif; ?>
+                            </div>
+                            <div class="timeline-content">
+                                <div class="timeline-title">
+                                    <?php echo $booking->status === 'completed' ?
+                                        __('Service Completed', 'mobooking') : __('Service Scheduled', 'mobooking'); ?>
+                                </div>
+                                <div class="timeline-time"><?php echo $service_date->format('M j, Y \a\t g:i A'); ?></div>
+                                <div class="timeline-description">
+                                    <?php echo $booking->status === 'completed' ?
+                                        __('Service has been completed successfully', 'mobooking') :
+                                        __('Scheduled service date and time', 'mobooking'); ?>
+                                </div>
+                            </div>
+                        </div>
+
+                        <?php if ($booking->status === 'cancelled') : ?>
+                            <div class="timeline-item cancelled">
+                                <div class="timeline-marker">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="12" cy="12" r="10"/>
+                                        <path d="M15 9l-6 6M9 9l6 6"/>
+                                    </svg>
+                                </div>
+                                <div class="timeline-content">
+                                    <div class="timeline-title"><?php _e('Booking Cancelled', 'mobooking'); ?></div>
+                                    <div class="timeline-time"><?php echo $updated_date->format('M j, Y \a\t g:i A'); ?></div>
+                                    <div class="timeline-description"><?php _e('This booking has been cancelled', 'mobooking'); ?></div>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+jQuery(document).ready(function($) {
+    // New handler for status dropdown change
+    $('#booking-status-changer').on('change', function() {
+        const $dropdown = $(this);
+        const bookingId = $dropdown.data('booking-id');
+        const newStatus = $dropdown.val();
+        const currentStatus = $dropdown.data('current-status'); // Store initial status to revert
+
+        if (newStatus === currentStatus) {
+            return; // No change
+        }
+
+        let confirmMessage = '<?php echo esc_js(__('Are you sure you want to change the booking status to ', 'mobooking')); ?>' + newStatus.charAt(0).toUpperCase() + newStatus.slice(1) + '?';
+
+        if (newStatus === 'cancelled') {
+            confirmMessage = '<?php echo esc_js(__('Cancel this booking? This action cannot be undone.', 'mobooking')); ?>';
+        } else if (newStatus === 'completed' && currentStatus !== 'completed') {
+            confirmMessage = '<?php echo esc_js(__('Mark this booking as completed?', 'mobooking')); ?>';
+        } else if (newStatus === 'confirmed' && currentStatus === 'pending') {
+            confirmMessage = '<?php echo esc_js(__('Confirm this booking?', 'mobooking')); ?>';
+        }
+
+        // Use a general confirmation, or only for specific transitions like 'cancelled'
+        if (confirm(confirmMessage)) {
+            // Add a visual loading state if possible
+            $dropdown.prop('disabled', true).css('opacity', 0.7);
+
+            $.ajax({
+                url: '<?php echo admin_url('admin-ajax.php'); ?>',
+                type: 'POST',
+                data: {
+                    action: 'mobooking_update_booking_status',
+                    booking_id: bookingId,
+                    status: newStatus,
+                    nonce: '<?php echo wp_create_nonce('mobooking-booking-nonce'); // Confirm this nonce is appropriate for the AJAX handler ?>'
+                },
+                success: function(response) {
+                    if (response.success) {
+                        // Update current status data attribute and reload for full consistency
+                        $dropdown.data('current-status', newStatus);
+                        location.reload();
+                    } else {
+                        alert(response.data.message || response.data || '<?php echo esc_js(__('Error updating booking status', 'mobooking')); ?>');
+                        $dropdown.prop('disabled', false).css('opacity', 1);
+                        $dropdown.val(currentStatus); // Revert to original status on failure
+                    }
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    alert('<?php echo esc_js(__('AJAX error updating booking status:', 'mobooking')); ?> ' + textStatus + ' - ' + errorThrown);
+                    $dropdown.prop('disabled', false).css('opacity', 1);
+                    $dropdown.val(currentStatus); // Revert to original status on failure
+                }
+            });
+        } else {
+            $dropdown.val(currentStatus); // Revert if confirmation is cancelled
+        }
+    });
+
+    // Old button handlers are removed by replacing the HTML for header-actions.
+    // If any other JS depends on them, that might need adjustment, but assumed not for now.
+});
+</script>
+
+<style>
+/* (styles unchanged for brevity) */
+/* New Two-Column Layout Styles */
+.single-booking-content.new-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+.booking-main-details {
+    flex: 2; /* Approx 66-70% */
+    min-width: 0; /* Prevent overflow */
+}
+.booking-sidebar {
+    flex: 1; /* Approx 30-33% */
+    min-width: 320px; /* Minimum width for sidebar */
+}
+.booking-main-details .booking-details-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+}
+
+@media (max-width: 1024px) {
+    .single-booking-content.new-layout {
+        flex-direction: column;
+    }
+    .booking-main-details,
+    .booking-sidebar {
+        flex: 1 1 100%;
+    }
+}
+</style>
+
+
+<style>
+/* Single Booking Page Styles */
+.single-booking-page {
+    max-width: 1400px;
+    margin: 0 auto;
+    animation: fadeIn 0.6s ease-out;
+}
+
+/* Header */
+.single-booking-header {
+    margin-bottom: 2rem;
+}
+
+.header-navigation {
+    margin-bottom: 1rem;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(var(--muted-foreground));
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.5rem 0;
+    transition: color 0.2s ease;
+}
+
+.back-link:hover {
+    color: hsl(var(--primary));
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+    padding: 2rem;
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+}
+
+.header-main {
+    flex: 1;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+}
+
+.booking-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem 0;
+    color: hsl(var(--foreground));
+}
+
+.booking-id-highlight {
+    color: hsl(var(--primary));
+    font-family: ui-monospace, 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
+}
+
+.booking-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.created-date,
+.updated-date {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.status-section {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid;
+}
+
+.status-pending {
+    background: hsl(var(--warning) / 0.1);
+    color: hsl(var(--warning));
+    border-color: hsl(var(--warning) / 0.3);
+}
+
+.status-confirmed {
+    background: hsl(var(--info) / 0.1);
+    color: hsl(var(--info));
+    border-color: hsl(var(--info) / 0.3);
+}
+
+.status-completed {
+    background: hsl(var(--success) / 0.1);
+    color: hsl(var(--success));
+    border-color: hsl(var(--success) / 0.3);
+}
+
+.status-cancelled {
+    background: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+    border-color: hsl(var(--destructive) / 0.3);
+}
+
+.urgency-badge {
+    padding: 0.375rem 0.75rem;
+    border-radius: 16px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.urgency-badge.today {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.urgency-badge.tomorrow {
+    background: #dbeafe;
+    color: #1e40af;
+}
+
+.urgency-badge.overdue {
+    background: #fee2e2;
+    color: #991b1b;
+    animation: pulse 1.5s infinite;
+}
+
+.urgency-badge.soon {
+    background: #f3e8ff;
+    color: #7c3aed;
+}
+
+.header-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.btn-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-decoration: none;
+}
+
+.btn-confirm {
+    background: hsl(var(--success) / 0.1);
+    border-color: hsl(var(--success) / 0.3);
+    color: hsl(var(--success));
+}
+
+.btn-confirm:hover {
+    background: hsl(var(--success) / 0.2);
+    border-color: hsl(var(--success));
+}
+
+.btn-complete {
+    background: hsl(var(--info) / 0.1);
+    border-color: hsl(var(--info) / 0.3);
+    color: hsl(var(--info));
+}
+
+.btn-complete:hover {
+    background: hsl(var(--info) / 0.2);
+    border-color: hsl(var(--info));
+}
+
+.btn-cancel {
+    background: hsl(var(--destructive) / 0.1);
+    border-color: hsl(var(--destructive) / 0.3);
+    color: hsl(var(--destructive));
+}
+
+.btn-cancel:hover {
+    background: hsl(var(--destructive) / 0.2);
+    border-color: hsl(var(--destructive));
+}
+
+.btn-action.loading {
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.btn-action.loading::after {
+    content: '';
+    width: 14px;
+    height: 14px;
+    border: 2px solid currentColor;
+    border-top: 2px solid transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-left: 0.5rem;
+}
+
+/* Main Content Grid */
+.booking-details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 1.5rem;
+}
+
+/* Detail Cards */
+.detail-card {
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: 12px;
+    overflow: hidden;
+    transition: all 0.3s ease;
+}
+
+.detail-card:hover {
+    box-shadow: 0 8px 20px hsl(var(--primary) / 0.1);
+    transform: translateY(-2px);
+}
+
+.card-header {
+    padding: 1.5rem 1.5rem 0 1.5rem;
+    border-bottom: 1px solid hsl(var(--border));
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+}
+
+.card-title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0;
+    color: hsl(var(--foreground));
+}
+
+.card-content {
+    padding: 0 1.5rem 1.5rem 1.5rem;
+}
+
+/* Customer Card */
+.customer-profile {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.customer-avatar-large {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.8));
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 1.25rem;
+    flex-shrink: 0;
+}
+
+.customer-info h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem 0;
+    color: hsl(var(--foreground));
+}
+
+.contact-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.contact-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.contact-link {
+    color: hsl(var(--foreground));
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: color 0.2s ease;
+}
+
+.contact-link:hover {
+    color: hsl(var(--primary));
+}
+
+/* DateTime Card */
+.datetime-display {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem;
+    background: hsl(var(--muted) / 0.3);
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+
+.date-section,
+.time-section {
+    text-align: center;
+}
+
+.date-main,
+.time-main {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+    margin-bottom: 0.25rem;
+}
+
+.date-full,
+.timezone {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.countdown {
+    text-align: center;
+    padding: 1rem;
+    background: hsl(var(--primary) / 0.1);
+    border-radius: 8px;
+    border: 1px solid hsl(var(--primary) / 0.2);
+}
+
+.countdown-label {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    margin-bottom: 0.5rem;
+}
+
+.countdown-value {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: hsl(var(--primary));
+}
+
+/* Address Card */
+.address-display {
+    margin-bottom: 1rem;
+}
+
+.address-text {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: hsl(var(--foreground));
+    margin-bottom: 0.75rem;
+}
+
+.zip-code {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.zip-label {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.zip-value {
+    font-weight: 600;
+    color: hsl(var(--foreground));
+    font-family: ui-monospace, 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
+}
+
+.address-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.map-link,
+.directions-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.875rem;
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    text-decoration: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.map-link:hover,
+.directions-link:hover {
+    background: hsl(var(--accent));
+    transform: translateY(-1px);
+}
+
+/* Services Card */
+.services-list {
+    margin-bottom: 1.5rem;
+}
+
+.service-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 1rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    background: hsl(var(--muted) / 0.2);
+}
+
+.service-item:last-child {
+    margin-bottom: 0;
+}
+
+.service-info {
+    flex: 1;
+}
+
+.service-name {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem 0;
+    color: hsl(var(--foreground));
+}
+
+.service-description {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    margin: 0 0 0.5rem 0;
+    line-height: 1.4;
+}
+
+.service-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.service-duration {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.service-price {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: hsl(var(--foreground));
+}
+
+.service-options {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid hsl(var(--border));
+}
+
+.options-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(var(--muted-foreground));
+    margin: 0 0 0.5rem 0;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.option-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.25rem 0;
+    font-size: 0.875rem;
+}
+
+.option-name {
+    color: hsl(var(--muted-foreground));
+}
+
+.option-value {
+    font-weight: 500;
+    color: hsl(var(--foreground));
+}
+
+.no-services {
+    text-align: center;
+    padding: 2rem;
+    color: hsl(var(--muted-foreground));
+}
+
+/* Pricing Summary */
+.pricing-summary {
+    border-top: 1px solid hsl(var(--border));
+    padding-top: 1rem;
+}
+
+.pricing-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+    font-size: 0.875rem;
+}
+
+.pricing-line.total {
+    border-top: 1px solid hsl(var(--border));
+    margin-top: 0.5rem;
+    padding-top: 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.pricing-line.discount .label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(var(--success));
+}
+
+.discount-code {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    font-weight: normal;
+}
+
+.discount-amount {
+    color: hsl(var(--success));
+}
+
+.total-amount {
+    color: hsl(var(--foreground));
+    font-size: 1.25rem;
+}
+
+/* Notes Card */
+.notes-content {
+    padding: 1rem;
+    background: hsl(var(--muted) / 0.3);
+    border-radius: 8px;
+    border-left: 4px solid hsl(var(--primary));
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: hsl(var(--foreground));
+}
+
+/* Timeline Card */
+.timeline {
+    position: relative;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 1rem;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: hsl(var(--border));
+}
+
+.timeline-item {
+    position: relative;
+    display: flex;
+    gap: 1rem;
+    padding-bottom: 1.5rem;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-marker {
+    position: relative;
+    z-index: 1;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background: hsl(var(--card));
+    border: 2px solid hsl(var(--border));
+}
+
+.timeline-item.completed .timeline-marker {
+    background: hsl(var(--success));
+    border-color: hsl(var(--success));
+    color: white;
+}
+
+.timeline-item.pending .timeline-marker {
+    background: hsl(var(--warning));
+    border-color: hsl(var(--warning));
+    color: white;
+    animation: pulse 2s infinite;
+}
+
+.timeline-item.cancelled .timeline-marker {
+    background: hsl(var(--destructive));
+    border-color: hsl(var(--destructive));
+    color: white;
+}
+
+.timeline-item.future .timeline-marker {
+    background: hsl(var(--muted));
+    border-color: hsl(var(--muted-foreground));
+    color: hsl(var(--muted-foreground));
+}
+
+.timeline-content {
+    flex: 1;
+    padding-top: 0.125rem;
+}
+
+.timeline-title {
+    font-weight: 600;
+    color: hsl(var(--foreground));
+    margin-bottom: 0.25rem;
+}
+
+.timeline-time {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    margin-bottom: 0.25rem;
+}
+
+.timeline-description {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    line-height: 1.4;
+}
+
+.pending-text {
+    color: hsl(var(--warning));
+    font-weight: 500;
+}
+
+/* Not Found State */
+.booking-not-found {
+    text-align: center;
+    padding: 4rem 2rem;
+    background: hsl(var(--card));
+    border: 2px dashed hsl(var(--border));
+    border-radius: 12px;
+}
+
+.not-found-icon {
+    margin-bottom: 1.5rem;
+    color: hsl(var(--muted-foreground));
+    opacity: 0.6;
+}
+
+.booking-not-found h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 1rem 0;
+    color: hsl(var(--foreground));
+}
+
+.booking-not-found p {
+    font-size: 1rem;
+    color: hsl(var(--muted-foreground));
+    margin: 0 0 2rem 0;
+    max-width: 24rem;
+    margin-left: auto;
+    margin-right: auto;
+    line-height: 1.6;
+}
+
+/* Responsive Design */
+@media (max-width: 1024px) {
+    .booking-details-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .header-content {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.5rem;
+    }
+
+    .header-main {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .status-section {
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .single-booking-page {
+        padding: 0 0.5rem;
+    }
+
+    .header-content {
+        padding: 1.5rem;
+    }
+
+    .booking-title {
+        font-size: 1.5rem;
+    }
+
+    .header-actions {
+        flex-direction: column;
+    }
+
+    .btn-action {
+        justify-content: center;
+        width: 100%;
+    }
+
+    .datetime-display {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .service-item {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: stretch;
+    }
+
+    .service-price {
+        text-align: right;
+    }
+
+    .address-actions {
+        flex-direction: column;
+    }
+
+    .map-link,
+    .directions-link {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .detail-card {
+        border-radius: 8px;
+    }
+
+    .card-header,
+    .card-content {
+        padding: 1rem;
+    }
+
+    .customer-profile {
+        flex-direction: column;
+        text-align: center;
+        gap: 1rem;
+    }
+
+    .contact-details {
+        align-items: center;
+    }
+
+    .timeline::before {
+        left: 0.75rem;
+    }
+
+    .timeline-marker {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+}
+
+/* Print Styles */
+@media print {
+    .single-booking-header .header-actions,
+    .address-actions,
+    .back-link {
+        display: none;
+    }
+
+    .single-booking-page {
+        max-width: none;
+    }
+
+    .booking-details-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .detail-card {
+        break-inside: avoid;
+        border: 2px solid #333;
+        margin-bottom: 1rem;
+    }
+
+    .header-content {
+        border: 2px solid #333;
+    }
+}
+
+/* High Contrast Mode */
+@media (prefers-contrast: high) {
+    .detail-card {
+        border-width: 2px;
+    }
+
+    .timeline-marker {
+        border-width: 3px;
+    }
+
+    .status-badge {
+        border-width: 2px;
+    }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+/* Animations */
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.8;
+        transform: scale(1.05);
+    }
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+/* New Two-Column Layout Styles */
+.single-booking-content.new-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+.booking-main-details {
+    flex: 2; /* Approx 66-70% */
+    min-width: 0; /* Prevent overflow */
+}
+.booking-sidebar {
+    flex: 1; /* Approx 30-33% */
+    min-width: 320px; /* Minimum width for sidebar */
+}
+.booking-main-details .booking-details-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+}
+
+@media (max-width: 1024px) {
+    .single-booking-content.new-layout {
+        flex-direction: column;
+    }
+    .booking-main-details,
+    .booking-sidebar {
+        flex: 1 1 100%;
+    }
+}
+</style>


### PR DESCRIPTION
Here's what I did:

- Created new page-*.php files in the root directory for each dashboard section (areas, booking-form, bookings, discounts, overview, services, settings, single-booking).
- Updated dashboard/index.php to remove the old section loading logic and default to page-overview.php.
- Modified dashboard/sidebar.php to update navigation links to point to the new page files and adjusted active section detection.
- Updated the include path in page-bookings.php to correctly load page-single-booking.php.
- Implemented rewrite rules in includes/rewrite-rules.php to internally handle the old ?section= URLs and load content from the new page-*.php files. This ensures backward compatibility and proper display with the dashboard header and footer.