### PR TITLE
Fix: Resolve fatal errors in dashboard pages

### DIFF
--- a/classes/Geography/Manager.php
+++ b/classes/Geography/Manager.php
@@ -47,6 +47,38 @@ class Manager {
             error_log('MoBooking\Geography\Manager: Enhanced constructor with external API integration');
         }
     }
+
+    /**
+     * Get a list of supported countries with their properties.
+     *
+     * @return array Associative array of countries. Key is country code, value is an array with 'name', 'has_local_data', 'has_api'.
+     */
+    public function get_supported_countries() {
+        // Define countries based on the structure in get_major_cities_for_country and page-areas.php requirements
+        $countries = array(
+            'US' => array('name' => 'United States', 'has_local_data' => false, 'has_api' => true),
+            'CA' => array('name' => 'Canada', 'has_local_data' => false, 'has_api' => true),
+            'GB' => array('name' => 'United Kingdom', 'has_local_data' => false, 'has_api' => true),
+            'DE' => array('name' => 'Germany', 'has_local_data' => false, 'has_api' => true),
+            'FR' => array('name' => 'France', 'has_local_data' => false, 'has_api' => true),
+            'ES' => array('name' => 'Spain', 'has_local_data' => false, 'has_api' => true),
+            'IT' => array('name' => 'Italy', 'has_local_data' => false, 'has_api' => true),
+            'AU' => array('name' => 'Australia', 'has_local_data' => false, 'has_api' => true),
+            'SE' => array('name' => 'Sweden', 'has_local_data' => true, 'has_api' => false), // Nordic, assumed local
+            'CY' => array('name' => 'Cyprus', 'has_local_data' => false, 'has_api' => true),
+            // Add other Nordic countries as per page-areas.php if desired, e.g.:
+            // 'NO' => array('name' => 'Norway', 'has_local_data' => true, 'has_api' => false),
+            // 'DK' => array('name' => 'Denmark', 'has_local_data' => true, 'has_api' => false),
+            // 'FI' => array('name' => 'Finland', 'has_local_data' => true, 'has_api' => false),
+        );
+
+        // Sort by country name for display
+        uasort($countries, function($a, $b) {
+            return strcmp($a['name'], $b['name']);
+        });
+
+        return $countries;
+    }
     
     /**
      * AJAX: Fetch areas/neighborhoods for a selected city using external APIs

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -41,25 +41,37 @@ global $wp_query; // Ensure $wp_query is available
 $current_section = 'overview'; // Default
 
 if (!empty($_GET['section'])) {
-    $current_section = sanitize_text_field($_GET['section']);
+    $current_section = sanitize_key($_GET['section']);
 } elseif (!empty($wp_query->query_vars['section'])) {
-    $current_section = sanitize_text_field($wp_query->query_vars['section']);
+    $current_section = sanitize_key($wp_query->query_vars['section']);
 }
+// The str_replace for backslashes is no longer needed as sanitize_key handles disallowed characters.
 
-// Further sanitize: remove any backslashes that might have been manually added or passed
-$current_section = str_replace('\\', '', $current_section); // Keep this sanitization
+// Settings are now loaded via mobooking_setup_dashboard_globals() before section content.
 
-// Quick settings load - only what's needed for layout
-$settings = (object) array(
-    'company_name' => get_user_meta($user_id, 'mobooking_company_name', true) ?: $current_user->display_name . "'s Business",
-    'primary_color' => '#4CAF50',
-    'logo_url' => '',
-    'phone' => '',
-    'email_header' => '',
-    'email_footer' => '',
-    'terms_conditions' => '',
-    'booking_confirmation_message' => 'Thank you for your booking.'
-);
+// MOVED: Call mobooking_setup_dashboard_globals() here to ensure all managers and $settings are loaded
+// before any dashboard HTML (including sidebar and header) is rendered.
+if (function_exists('mobooking_setup_dashboard_globals')) {
+    if (!mobooking_setup_dashboard_globals()) {
+        // The function returned false, likely due to user not being logged in
+        // and already handled a redirect. Or some other critical setup failure.
+        // We should probably exit here if it returns false, as it implies a redirect or failure.
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('MoBooking Info: mobooking_setup_dashboard_globals() returned false. Halting further dashboard rendering in template.');
+        }
+        // Depending on how mobooking_setup_dashboard_globals handles failed auth (e.g. if it always exits),
+        // this exit might be redundant or a safeguard.
+        exit;
+    }
+} else {
+    // Fallback or error if the crucial setup function is missing
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log('MoBooking Error: mobooking_setup_dashboard_globals() function not found. Dashboard cannot be properly rendered.');
+    }
+    // Display a user-friendly error and exit, as the dashboard will be broken.
+    wp_die(__('A critical setup function is missing. The dashboard cannot be displayed. Please contact support.', 'mobooking'));
+    exit;
+}
 ?>
 
 <!-- RENDER LAYOUT IMMEDIATELY -->
@@ -83,37 +95,25 @@ $settings = (object) array(
         
         <div class="dashboard-content">
             <?php
-            // Include page-overview.php by default
-            $overview_file = MOBOOKING_PATH . '/page-overview.php';
-            if (file_exists($overview_file)) {
-                // Initialize managers needed for overview.php, if not already done
-                // This ensures that variables like $bookings_manager are available in page-overview.php
-                if (!isset($bookings_manager)) {
-                    $bookings_manager = new \MoBooking\Bookings\Manager();
-                }
-                if (!isset($services_manager)) {
-                    $services_manager = new \MoBooking\Services\ServicesManager();
-                }
-                if (!isset($geography_manager)) {
-                    $geography_manager = new \MoBooking\Geography\Manager();
-                }
-                if(!isset($settings_manager)) {
-                    $settings_manager = new \MoBooking\Database\SettingsManager();
-                    // $settings is already defined above, but if overview needs its own, adjust here
-                    // For now, we assume $settings from above is sufficient or page-overview.php handles its own settings if needed.
-                }
-                include $overview_file;
+            // Dynamically load the section content
+            $section_file_name = 'page-' . $current_section . '.php';
+            $section_file_path = MOBOOKING_PATH . '/' . $section_file_name;
+
+            if (file_exists($section_file_path)) {
+                // Managers and $settings are already loaded globally now by the call
+                // to mobooking_setup_dashboard_globals() near the top of this file.
+                include $section_file_path;
+
             } else {
-                // Fallback if page-overview.php is missing
+                // Fallback if the specific section page (e.g., page-services.php) is missing
                 echo '<div class="mobooking-fallback-content">
-       <h2>' . __('Welcome to your Dashboard', 'mobooking') . '</h2>
-       <p>' . __('The main overview page could not be loaded. Please ensure all plugin files are correctly installed.', 'mobooking') . '</p>
-       </div>';
-                 if (defined('WP_DEBUG') && WP_DEBUG) {
-                    error_log('MoBooking: page-overview.php file not found at: ' . $overview_file);
+<h2>' . sprintf(__('Section Not Found: %s', 'mobooking'), esc_html($current_section)) . '</h2>
+<p>' . __('The requested dashboard section could not be loaded. Please ensure all plugin/theme files are correctly installed or contact support.', 'mobooking') . '</p>
+</div>';
+                if (defined('WP_DEBUG') && WP_DEBUG) {
+                    error_log('MoBooking: Section file not found: ' . $section_file_path);
                 }
             }
-            // Removed extra ?> here
         </div>
     </div>
 </div>

--- a/page-areas.php
+++ b/page-areas.php
@@ -6,8 +6,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Initialize managers
-$geography_manager = new \MoBooking\Geography\Manager();
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
+// Managers are now initialized globally by mobooking_setup_dashboard_globals().
+// $geography_manager is available here via the global keyword.
 $areas = $geography_manager->get_user_areas($user_id);
 
 // Get coverage statistics

--- a/page-booking-form.php
+++ b/page-booking-form.php
@@ -6,19 +6,23 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Initialize booking form manager
-$booking_form_manager = new \MoBooking\BookingForm\BookingFormManager();
-$settings = $booking_form_manager->get_settings($user_id);
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
+// Managers are now initialized globally by mobooking_setup_dashboard_globals().
+// They are available here via the global keyword.
+
+// Local $settings for booking form specific settings, shadows global $settings
+$_booking_form_settings = $booking_form_manager->get_settings($user_id); // Renamed to avoid conflict with global $settings
 $booking_url = $booking_form_manager->get_booking_form_url($user_id);
 $embed_url = $booking_form_manager->get_embed_url($user_id);
 
 // Get user's services count for validation
-$services_manager = new \MoBooking\Services\ServicesManager();
 $services = $services_manager->get_user_services($user_id);
 $services_count = count($services);
 
 // Get geography areas count
-$geography_manager = new \MoBooking\Geography\Manager();
 $areas = $geography_manager->get_user_areas($user_id);
 $areas_count = count($areas);
 
@@ -855,14 +859,14 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                 <div class="form-group">
                                     <label for="form-title" class="field-label required"><?php _e('Form Title', 'mobooking'); ?></label>
                                     <input type="text" id="form-title" name="form_title" class="form-control"
-                                           value="<?php echo esc_attr($settings->form_title); ?>" required>
+                                           value="<?php echo esc_attr($_booking_form_settings->form_title); ?>" required>
                                     <small class="field-note"><?php _e('This appears as the main heading on your booking form', 'mobooking'); ?></small>
                                 </div>
 
                                 <div class="form-group">
                                     <label for="form-description" class="field-label"><?php _e('Form Description', 'mobooking'); ?></label>
                                     <textarea id="form-description" name="form_description" class="form-control" rows="3"
-                                              placeholder="<?php _e('Book our professional services quickly and easily...', 'mobooking'); ?>"><?php echo esc_textarea($settings->form_description); ?></textarea>
+                                              placeholder="<?php _e('Book our professional services quickly and easily...', 'mobooking'); ?>"><?php echo esc_textarea($_booking_form_settings->form_description); ?></textarea>
                                     <small class="field-note"><?php _e('Brief description shown below the title', 'mobooking'); ?></small>
                                 </div>
 
@@ -870,19 +874,19 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                     <div class="form-group">
                                         <label for="language" class="field-label"><?php _e('Language', 'mobooking'); ?></label>
                                         <select id="language" name="language" class="form-control">
-                                            <option value="en" <?php selected($settings->language, 'en'); ?>><?php _e('English', 'mobooking'); ?></option>
-                                            <option value="es" <?php selected($settings->language, 'es'); ?>><?php _e('Spanish', 'mobooking'); ?></option>
-                                            <option value="fr" <?php selected($settings->language, 'fr'); ?>><?php _e('French', 'mobooking'); ?></option>
-                                            <option value="de" <?php selected($settings->language, 'de'); ?>><?php _e('German', 'mobooking'); ?></option>
-                                            <option value="it" <?php selected($settings->language, 'it'); ?>><?php _e('Italian', 'mobooking'); ?></option>
+                                            <option value="en" <?php selected($_booking_form_settings->language, 'en'); ?>><?php _e('English', 'mobooking'); ?></option>
+                                            <option value="es" <?php selected($_booking_form_settings->language, 'es'); ?>><?php _e('Spanish', 'mobooking'); ?></option>
+                                            <option value="fr" <?php selected($_booking_form_settings->language, 'fr'); ?>><?php _e('French', 'mobooking'); ?></option>
+                                            <option value="de" <?php selected($_booking_form_settings->language, 'de'); ?>><?php _e('German', 'mobooking'); ?></option>
+                                            <option value="it" <?php selected($_booking_form_settings->language, 'it'); ?>><?php _e('Italian', 'mobooking'); ?></option>
                                         </select>
                                     </div>
 
                                     <div class="form-group">
                                         <label for="is-active" class="field-label"><?php _e('Form Status', 'mobooking'); ?></label>
                                         <select id="is-active" name="is_active" class="form-control">
-                                            <option value="1" <?php selected($settings->is_active, 1); ?>><?php _e('Active', 'mobooking'); ?></option>
-                                            <option value="0" <?php selected($settings->is_active, 0); ?>><?php _e('Inactive', 'mobooking'); ?></option>
+                                            <option value="1" <?php selected($_booking_form_settings->is_active, 1); ?>><?php _e('Active', 'mobooking'); ?></option>
+                                            <option value="0" <?php selected($_booking_form_settings->is_active, 0); ?>><?php _e('Inactive', 'mobooking'); ?></option>
                                         </select>
                                     </div>
                                 </div>
@@ -900,7 +904,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                 <div class="checkbox-grid">
                                     <div class="checkbox-option">
                                         <input type="checkbox" id="show-form-header" name="show_form_header" value="1"
-                                               <?php checked($settings->show_form_header, 1); ?>>
+                                               <?php checked($_booking_form_settings->show_form_header, 1); ?>>
                                         <div class="checkbox-content">
                                             <div class="checkbox-title"><?php _e('Show Form Header', 'mobooking'); ?></div>
                                             <div class="checkbox-desc"><?php _e('Display title, description, and logo at the top', 'mobooking'); ?></div>
@@ -909,7 +913,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
 
                                     <div class="checkbox-option">
                                         <input type="checkbox" id="show-service-descriptions" name="show_service_descriptions" value="1"
-                                               <?php checked($settings->show_service_descriptions, 1); ?>>
+                                               <?php checked($_booking_form_settings->show_service_descriptions, 1); ?>>
                                         <div class="checkbox-content">
                                             <div class="checkbox-title"><?php _e('Show Service Descriptions', 'mobooking'); ?></div>
                                             <div class="checkbox-desc"><?php _e('Display detailed descriptions for each service', 'mobooking'); ?></div>
@@ -918,7 +922,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
 
                                     <div class="checkbox-option">
                                         <input type="checkbox" id="show-price-breakdown" name="show_price_breakdown" value="1"
-                                               <?php checked($settings->show_price_breakdown, 1); ?>>
+                                               <?php checked($_booking_form_settings->show_price_breakdown, 1); ?>>
                                         <div class="checkbox-content">
                                             <div class="checkbox-title"><?php _e('Show Price Breakdown', 'mobooking'); ?></div>
                                             <div class="checkbox-desc"><?php _e('Display detailed pricing information', 'mobooking'); ?></div>
@@ -927,7 +931,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
 
                                     <div class="checkbox-option">
                                         <input type="checkbox" id="enable-zip-validation" name="enable_zip_validation" value="1"
-                                               <?php checked($settings->enable_zip_validation, 1); ?>>
+                                               <?php checked($_booking_form_settings->enable_zip_validation, 1); ?>>
                                         <div class="checkbox-content">
                                             <div class="checkbox-title"><?php _e('ZIP Code Validation', 'mobooking'); ?></div>
                                             <div class="checkbox-desc"><?php _e('Validate ZIP codes for service area coverage', 'mobooking'); ?></div>
@@ -936,7 +940,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
 
                                     <div class="checkbox-option">
                                         <input type="checkbox" id="show-form-footer" name="show_form_footer" value="1"
-                                               <?php checked($settings->show_form_footer, 1); ?>>
+                                               <?php checked($_booking_form_settings->show_form_footer, 1); ?>>
                                         <div class="checkbox-content">
                                             <div class="checkbox-title"><?php _e('Show Form Footer', 'mobooking'); ?></div>
                                             <div class="checkbox-desc"><?php _e('Display footer content and social links', 'mobooking'); ?></div>
@@ -964,8 +968,8 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                         <label for="primary-color" class="field-label"><?php _e('Primary Color', 'mobooking'); ?></label>
                                         <div class="color-input-group">
                                             <input type="color" id="primary-color" name="primary_color"
-                                                   value="<?php echo esc_attr($settings->primary_color); ?>" class="color-picker">
-                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->primary_color); ?>" readonly>
+                                                   value="<?php echo esc_attr($_booking_form_settings->primary_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($_booking_form_settings->primary_color); ?>" readonly>
                                         </div>
                                     </div>
 
@@ -973,8 +977,8 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                         <label for="secondary-color" class="field-label"><?php _e('Secondary Color', 'mobooking'); ?></label>
                                         <div class="color-input-group">
                                             <input type="color" id="secondary-color" name="secondary_color"
-                                                   value="<?php echo esc_attr($settings->secondary_color); ?>" class="color-picker">
-                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->secondary_color); ?>" readonly>
+                                                   value="<?php echo esc_attr($_booking_form_settings->secondary_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($_booking_form_settings->secondary_color); ?>" readonly>
                                         </div>
                                     </div>
                                 </div>
@@ -984,8 +988,8 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                         <label for="background-color" class="field-label"><?php _e('Background Color', 'mobooking'); ?></label>
                                         <div class="color-input-group">
                                             <input type="color" id="background-color" name="background_color"
-                                                   value="<?php echo esc_attr($settings->background_color); ?>" class="color-picker">
-                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->background_color); ?>" readonly>
+                                                   value="<?php echo esc_attr($_booking_form_settings->background_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($_booking_form_settings->background_color); ?>" readonly>
                                         </div>
                                     </div>
 
@@ -993,8 +997,8 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                         <label for="text-color" class="field-label"><?php _e('Text Color', 'mobooking'); ?></label>
                                         <div class="color-input-group">
                                             <input type="color" id="text-color" name="text_color"
-                                                   value="<?php echo esc_attr($settings->text_color); ?>" class="color-picker">
-                                            <input type="text" class="color-text" value="<?php echo esc_attr($settings->text_color); ?>" readonly>
+                                                   value="<?php echo esc_attr($_booking_form_settings->text_color); ?>" class="color-picker">
+                                            <input type="text" class="color-text" value="<?php echo esc_attr($_booking_form_settings->text_color); ?>" readonly>
                                         </div>
                                     </div>
                                 </div>
@@ -1013,19 +1017,19 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                     <div class="form-group">
                                         <label for="form-layout" class="field-label"><?php _e('Form Layout', 'mobooking'); ?></label>
                                         <select id="form-layout" name="form_layout" class="form-control">
-                                            <option value="modern" <?php selected($settings->form_layout, 'modern'); ?>><?php _e('Modern', 'mobooking'); ?></option>
-                                            <option value="classic" <?php selected($settings->form_layout, 'classic'); ?>><?php _e('Classic', 'mobooking'); ?></option>
-                                            <option value="minimal" <?php selected($settings->form_layout, 'minimal'); ?>><?php _e('Minimal', 'mobooking'); ?></option>
+                                            <option value="modern" <?php selected($_booking_form_settings->form_layout, 'modern'); ?>><?php _e('Modern', 'mobooking'); ?></option>
+                                            <option value="classic" <?php selected($_booking_form_settings->form_layout, 'classic'); ?>><?php _e('Classic', 'mobooking'); ?></option>
+                                            <option value="minimal" <?php selected($_booking_form_settings->form_layout, 'minimal'); ?>><?php _e('Minimal', 'mobooking'); ?></option>
                                         </select>
                                     </div>
 
                                     <div class="form-group">
                                         <label for="form-width" class="field-label"><?php _e('Form Width', 'mobooking'); ?></label>
                                         <select id="form-width" name="form_width" class="form-control">
-                                            <option value="narrow" <?php selected($settings->form_width, 'narrow'); ?>><?php _e('Narrow (600px)', 'mobooking'); ?></option>
-                                            <option value="standard" <?php selected($settings->form_width, 'standard'); ?>><?php _e('Standard (800px)', 'mobooking'); ?></option>
-                                            <option value="wide" <?php selected($settings->form_width, 'wide'); ?>><?php _e('Wide (1000px)', 'mobooking'); ?></option>
-                                            <option value="full" <?php selected($settings->form_width, 'full'); ?>><?php _e('Full Width', 'mobooking'); ?></option>
+                                            <option value="narrow" <?php selected($_booking_form_settings->form_width, 'narrow'); ?>><?php _e('Narrow (600px)', 'mobooking'); ?></option>
+                                            <option value="standard" <?php selected($_booking_form_settings->form_width, 'standard'); ?>><?php _e('Standard (800px)', 'mobooking'); ?></option>
+                                            <option value="wide" <?php selected($_booking_form_settings->form_width, 'wide'); ?>><?php _e('Wide (1000px)', 'mobooking'); ?></option>
+                                            <option value="full" <?php selected($_booking_form_settings->form_width, 'full'); ?>><?php _e('Full Width', 'mobooking'); ?></option>
                                         </select>
                                     </div>
                                 </div>
@@ -1034,21 +1038,21 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                     <div class="form-group">
                                         <label for="step-indicator-style" class="field-label"><?php _e('Step Indicator Style', 'mobooking'); ?></label>
                                         <select id="step-indicator-style" name="step_indicator_style" class="form-control">
-                                            <option value="progress" <?php selected($settings->step_indicator_style, 'progress'); ?>><?php _e('Progress Bar', 'mobooking'); ?></option>
-                                            <option value="dots" <?php selected($settings->step_indicator_style, 'dots'); ?>><?php _e('Dots', 'mobooking'); ?></option>
-                                            <option value="numbers" <?php selected($settings->step_indicator_style, 'numbers'); ?>><?php _e('Numbers', 'mobooking'); ?></option>
-                                            <option value="arrows" <?php selected($settings->step_indicator_style, 'arrows'); ?>><?php _e('Arrows', 'mobooking'); ?></option>
-                                            <option value="none" <?php selected($settings->step_indicator_style, 'none'); ?>><?php _e('None', 'mobooking'); ?></option>
+                                            <option value="progress" <?php selected($_booking_form_settings->step_indicator_style, 'progress'); ?>><?php _e('Progress Bar', 'mobooking'); ?></option>
+                                            <option value="dots" <?php selected($_booking_form_settings->step_indicator_style, 'dots'); ?>><?php _e('Dots', 'mobooking'); ?></option>
+                                            <option value="numbers" <?php selected($_booking_form_settings->step_indicator_style, 'numbers'); ?>><?php _e('Numbers', 'mobooking'); ?></option>
+                                            <option value="arrows" <?php selected($_booking_form_settings->step_indicator_style, 'arrows'); ?>><?php _e('Arrows', 'mobooking'); ?></option>
+                                            <option value="none" <?php selected($_booking_form_settings->step_indicator_style, 'none'); ?>><?php _e('None', 'mobooking'); ?></option>
                                         </select>
                                     </div>
 
                                     <div class="form-group">
                                         <label for="button-style" class="field-label"><?php _e('Button Style', 'mobooking'); ?></label>
                                         <select id="button-style" name="button_style" class="form-control">
-                                            <option value="rounded" <?php selected($settings->button_style, 'rounded'); ?>><?php _e('Rounded', 'mobooking'); ?></option>
-                                            <option value="square" <?php selected($settings->button_style, 'square'); ?>><?php _e('Square', 'mobooking'); ?></option>
-                                            <option value="pill" <?php selected($settings->button_style, 'pill'); ?>><?php _e('Pill', 'mobooking'); ?></option>
-                                            <option value="outline" <?php selected($settings->button_style, 'outline'); ?>><?php _e('Outline', 'mobooking'); ?></option>
+                                            <option value="rounded" <?php selected($_booking_form_settings->button_style, 'rounded'); ?>><?php _e('Rounded', 'mobooking'); ?></option>
+                                            <option value="square" <?php selected($_booking_form_settings->button_style, 'square'); ?>><?php _e('Square', 'mobooking'); ?></option>
+                                            <option value="pill" <?php selected($_booking_form_settings->button_style, 'pill'); ?>><?php _e('Pill', 'mobooking'); ?></option>
+                                            <option value="outline" <?php selected($_booking_form_settings->button_style, 'outline'); ?>><?php _e('Outline', 'mobooking'); ?></option>
                                         </select>
                                     </div>
                                 </div>
@@ -1071,7 +1075,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                 <div class="form-group">
                                     <label for="seo-title" class="field-label"><?php _e('Page Title', 'mobooking'); ?></label>
                                     <input type="text" id="seo-title" name="seo_title" class="form-control"
-                                           value="<?php echo esc_attr($settings->seo_title); ?>"
+                                           value="<?php echo esc_attr($_booking_form_settings->seo_title); ?>"
                                            placeholder="<?php _e('Book Our Services - Company Name', 'mobooking'); ?>">
                                     <small class="field-note"><?php _e('Appears in browser title bar and search results', 'mobooking'); ?></small>
                                 </div>
@@ -1079,7 +1083,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                 <div class="form-group">
                                     <label for="seo-description" class="field-label"><?php _e('Meta Description', 'mobooking'); ?></label>
                                     <textarea id="seo-description" name="seo_description" class="form-control" rows="3"
-                                              placeholder="<?php _e('Book our professional services easily online. Fast, reliable, and convenient scheduling...', 'mobooking'); ?>"><?php echo esc_textarea($settings->seo_description); ?></textarea>
+                                              placeholder="<?php _e('Book our professional services easily online. Fast, reliable, and convenient scheduling...', 'mobooking'); ?>"><?php echo esc_textarea($_booking_form_settings->seo_description); ?></textarea>
                                     <small class="field-note"><?php _e('Brief description for search engines (150-160 characters recommended)', 'mobooking'); ?></small>
                                 </div>
                             </div>
@@ -1097,7 +1101,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                     <label for="custom-css" class="field-label"><?php _e('Custom CSS', 'mobooking'); ?></label>
                                     <textarea id="custom-css" name="custom_css" class="form-control" rows="8"
                                               style="font-family: monospace;"
-                                              placeholder="<?php _e('/* Custom CSS styles */\n.booking-form {\n    /* Your styles here */\n}', 'mobooking'); ?>"><?php echo esc_textarea($settings->custom_css); ?></textarea>
+                                              placeholder="<?php _e('/* Custom CSS styles */\n.booking-form {\n    /* Your styles here */\n}', 'mobooking'); ?>"><?php echo esc_textarea($_booking_form_settings->custom_css); ?></textarea>
                                     <small class="field-note"><?php _e('Custom CSS will override default styles.', 'mobooking'); ?></small>
                                 </div>
 
@@ -1105,7 +1109,7 @@ $progress_percentage = round(($completed_steps / $total_steps) * 100);
                                     <label for="analytics-code" class="field-label"><?php _e('Analytics Code', 'mobooking'); ?></label>
                                     <textarea id="analytics-code" name="analytics_code" class="form-control" rows="6"
                                               style="font-family: monospace;"
-                                              placeholder="<?php _e('<!-- Google Analytics, Facebook Pixel, or other tracking codes -->', 'mobooking'); ?>"><?php echo esc_textarea($settings->analytics_code); ?></textarea>
+                                              placeholder="<?php _e('<!-- Google Analytics, Facebook Pixel, or other tracking codes -->', 'mobooking'); ?>"><?php echo esc_textarea($_booking_form_settings->analytics_code); ?></textarea>
                                     <small class="field-note"><?php _e('Add Google Analytics, Facebook Pixel, or other tracking codes', 'mobooking'); ?></small>
                                 </div>
                             </div>

--- a/page-bookings.php
+++ b/page-bookings.php
@@ -6,8 +6,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Initialize bookings manager
-$bookings_manager = new \MoBooking\Bookings\Manager();
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
+// Managers are now initialized globally by mobooking_setup_dashboard_globals().
+// They are available here via the global keyword.
 
 // Get current view (list or individual booking)
 $current_view = isset($_GET['view']) ? sanitize_text_field($_GET['view']) : 'list';
@@ -367,7 +371,7 @@ $upcoming_bookings = $bookings_manager->get_user_bookings($user_id, $upcoming_ar
                     <!-- Bookings List -->
                     <div class="bookings-list">
                     <?php
-                    $services_manager = new \MoBooking\Services\ServicesManager();
+                    // $services_manager is now global
                     foreach ($bookings as $booking) :
                             $services_data = is_array($booking->services) ? $booking->services : json_decode($booking->services, true);
                             $service_name = '';

--- a/page-discounts.php
+++ b/page-discounts.php
@@ -6,12 +6,21 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
 // Initialize discounts manager
 try {
-    $discounts_manager = new \MoBooking\Discounts\Manager();
+    // $discounts_manager is now expected to be globally available.
+    // If it's not, the catch block below will handle it.
+    if (!isset($discounts_manager) || !is_object($discounts_manager)) {
+        // This condition might be hit if mobooking_setup_dashboard_globals failed to set it up.
+        throw new Exception('Global $discounts_manager not available.');
+    }
 } catch (Exception $e) {
     if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('MoBooking: Failed to initialize Discounts Manager: ' . $e->getMessage());
+        error_log('MoBooking: Error accessing global Discounts Manager or it was not set up: ' . $e->getMessage());
     }
     // Create a fallback to prevent fatal errors
     $discounts_manager = new stdClass();

--- a/page-overview.php
+++ b/page-overview.php
@@ -6,20 +6,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Initialize managers and get data
-try {
-    $bookings_manager = new \MoBooking\Bookings\Manager();
-    $services_manager = new \MoBooking\Services\ServicesManager();
-    $geography_manager = new \MoBooking\Geography\Manager();
-} catch (Throwable $e) { // Changed Exception to Throwable
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('MoBooking: Failed to initialize managers in overview: ' . $e->getMessage());
-    }
-    // Create fallback objects
-    $bookings_manager = new stdClass();
-    $services_manager = new stdClass();
-    $geography_manager = new stdClass();
-}
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager;
+
+// Managers are now initialized globally by mobooking_setup_dashboard_globals()
+// and are available here via the global keyword.
+// Data fetching will use these global manager instances.
 
 // Get dashboard stats - with error handling
 $stats = array(
@@ -35,62 +28,62 @@ $stats = array(
 );
 
 try {
-    if (method_exists($bookings_manager, 'count_user_bookings')) {
+    if (is_object($bookings_manager) && method_exists($bookings_manager, 'count_user_bookings')) {
         $stats['total_bookings'] = $bookings_manager->count_user_bookings($user_id);
         $stats['pending_bookings'] = $bookings_manager->count_user_bookings($user_id, 'pending');
         $stats['confirmed_bookings'] = $bookings_manager->count_user_bookings($user_id, 'confirmed');
         $stats['completed_bookings'] = $bookings_manager->count_user_bookings($user_id, 'completed');
     }
 
-    if (method_exists($bookings_manager, 'calculate_user_revenue')) {
+    if (is_object($bookings_manager) && method_exists($bookings_manager, 'calculate_user_revenue')) {
         $stats['total_revenue'] = $bookings_manager->calculate_user_revenue($user_id);
         $stats['this_month_revenue'] = $bookings_manager->calculate_user_revenue($user_id, 'this_month');
         $stats['this_week_revenue'] = $bookings_manager->calculate_user_revenue($user_id, 'this_week');
         $stats['today_revenue'] = $bookings_manager->calculate_user_revenue($user_id, 'today');
     }
 
-    if (method_exists($bookings_manager, 'get_most_popular_service')) {
+    if (is_object($bookings_manager) && method_exists($bookings_manager, 'get_most_popular_service')) {
         $stats['most_popular_service'] = $bookings_manager->get_most_popular_service($user_id);
     }
 } catch (Exception $e) {
     if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('MoBooking: Error getting stats: ' . $e->getMessage());
+        error_log('MoBooking: Error getting stats in page-overview: ' . $e->getMessage());
     }
 }
 
 // Get recent bookings
 $recent_bookings = array();
 try {
-    if (method_exists($bookings_manager, 'get_user_bookings')) {
+    if (is_object($bookings_manager) && method_exists($bookings_manager, 'get_user_bookings')) {
         $recent_bookings = $bookings_manager->get_user_bookings($user_id, array('limit' => 5, 'order' => 'DESC'));
     }
 } catch (Exception $e) {
     if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('MoBooking: Error getting recent bookings: ' . $e->getMessage());
+        error_log('MoBooking: Error getting recent bookings in page-overview: ' . $e->getMessage());
     }
 }
 
 // Get user services
 $user_services = array();
 try {
-    if (method_exists($services_manager, 'get_user_services')) {
+    if (is_object($services_manager) && method_exists($services_manager, 'get_user_services')) {
         $user_services = $services_manager->get_user_services($user_id);
     }
 } catch (Exception $e) {
     if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('MoBooking: Error getting user services: ' . $e->getMessage());
+        error_log('MoBooking: Error getting user services in page-overview: ' . $e->getMessage());
     }
 }
 
 // Get user areas
 $user_areas = array();
 try {
-    if (method_exists($geography_manager, 'get_user_areas')) {
+    if (is_object($geography_manager) && method_exists($geography_manager, 'get_user_areas')) {
         $user_areas = $geography_manager->get_user_areas($user_id);
     }
 } catch (Exception $e) {
     if (defined('WP_DEBUG') && WP_DEBUG) {
-        error_log('MoBooking: Error getting user areas: ' . $e->getMessage());
+        error_log('MoBooking: Error getting user areas in page-overview: ' . $e->getMessage());
     }
 }
 

--- a/page-services.php
+++ b/page-services.php
@@ -11,13 +11,18 @@ $service_id = isset($_GET['service_id']) ? absint($_GET['service_id']) : 0;
 $active_tab = isset($_GET['active_tab']) ? sanitize_text_field($_GET['active_tab']) : 'basic-info';
 
 // Initialize managers
-$service_manager = new \MoBooking\Services\ServicesManager();
-$options_manager = new \MoBooking\Services\ServiceOptionsManager();
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
+// Use $services_manager (plural) consistent with global declaration.
+// $service_manager (singular) was used locally before.
+// $options_manager is also now global.
 
 // Handle service editing
 $service_data = null;
 if ($current_view === 'edit' && $service_id) {
-    $service_data = $service_manager->get_service($service_id, $user_id);
+    $service_data = $services_manager->get_service($service_id, $user_id); // Changed to $services_manager
     if (!$service_data) {
         $current_view = 'list';
     }
@@ -27,8 +32,8 @@ if ($current_view === 'edit' && $service_id) {
 $services = array();
 $categories = array();
 if ($current_view === 'list') {
-    $services = $service_manager->get_user_services($user_id);
-    $categories = $service_manager->get_user_categories($user_id);
+    $services = $services_manager->get_user_services($user_id); // Changed to $services_manager
+    $categories = $services_manager->get_user_categories($user_id); // Changed to $services_manager
 }
 
 // Available icons for services

--- a/page-settings.php
+++ b/page-settings.php
@@ -6,9 +6,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Initialize settings manager
-$settings_manager = new \MoBooking\Database\SettingsManager();
-$settings = $settings_manager->get_settings($user_id);
+global $user_id, $current_user, $settings, // $settings is the global one
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
+// Initialize settings manager for this page's specific settings
+$_page_settings = $settings_manager->get_settings($user_id); // Page-specific settings
 
 // Get user data
 $user_data = get_userdata($user_id);
@@ -120,7 +123,7 @@ $user_data = get_userdata($user_id);
                         <div class="field-group">
                             <label for="company-name" class="field-label required"><?php _e('Company Name', 'mobooking'); ?></label>
                             <input type="text" id="company-name" name="company_name" class="form-control"
-                                   value="<?php echo esc_attr($settings->company_name); ?>"
+                                   value="<?php echo esc_attr($_page_settings->company_name); ?>"
                                    placeholder="<?php _e('Your Company Name', 'mobooking'); ?>" required>
                             <p class="field-help"><?php _e('This name will appear on your booking forms and emails', 'mobooking'); ?></p>
                         </div>
@@ -128,7 +131,7 @@ $user_data = get_userdata($user_id);
                         <div class="field-group">
                             <label for="company-phone" class="field-label"><?php _e('Phone Number', 'mobooking'); ?></label>
                             <input type="tel" id="company-phone" name="phone" class="form-control"
-                                   value="<?php echo esc_attr($settings->phone); ?>"
+                                   value="<?php echo esc_attr($_page_settings->phone); ?>"
                                    placeholder="<?php _e('(555) 123-4567', 'mobooking'); ?>">
                             <p class="field-help"><?php _e('Contact phone number for customer inquiries', 'mobooking'); ?></p>
                         </div>
@@ -182,8 +185,8 @@ $user_data = get_userdata($user_id);
 
                         <div class="logo-upload-section">
                             <div class="logo-preview">
-                                <?php if (!empty($settings->logo_url)) : ?>
-                                    <img src="<?php echo esc_url($settings->logo_url); ?>" alt="<?php _e('Current Logo', 'mobooking'); ?>" class="current-logo">
+                                <?php if (!empty($_page_settings->logo_url)) : ?>
+                                    <img src="<?php echo esc_url($_page_settings->logo_url); ?>" alt="<?php _e('Current Logo', 'mobooking'); ?>" class="current-logo">
                                 <?php else : ?>
                                     <div class="logo-placeholder">
                                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -197,7 +200,7 @@ $user_data = get_userdata($user_id);
                             </div>
 
                             <div class="logo-upload-controls">
-                                <input type="hidden" id="logo-url" name="logo_url" value="<?php echo esc_attr($settings->logo_url); ?>">
+                                <input type="hidden" id="logo-url" name="logo_url" value="<?php echo esc_attr($_page_settings->logo_url); ?>">
                                 <button type="button" class="btn-secondary select-logo-btn">
                                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
@@ -207,7 +210,7 @@ $user_data = get_userdata($user_id);
                                     <?php _e('Upload Logo', 'mobooking'); ?>
                                 </button>
 
-                                <?php if (!empty($settings->logo_url)) : ?>
+                                <?php if (!empty($_page_settings->logo_url)) : ?>
                                     <button type="button" class="btn-secondary remove-logo-btn">
                                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                             <path d="m3 6 3 18h12l3-18"></path>
@@ -231,9 +234,9 @@ $user_data = get_userdata($user_id);
                                 <label for="primary-color" class="field-label"><?php _e('Primary Color', 'mobooking'); ?></label>
                                 <div class="color-input-group">
                                     <input type="color" id="primary-color" name="primary_color"
-                                           value="<?php echo esc_attr($settings->primary_color); ?>" class="color-picker">
-                                    <input type="text" class="color-text" value="<?php echo esc_attr($settings->primary_color); ?>" readonly>
-                                    <div class="color-preview" style="background-color: <?php echo esc_attr($settings->primary_color); ?>"></div>
+                                           value="<?php echo esc_attr($_page_settings->primary_color); ?>" class="color-picker">
+                                    <input type="text" class="color-text" value="<?php echo esc_attr($_page_settings->primary_color); ?>" readonly>
+                                    <div class="color-preview" style="background-color: <?php echo esc_attr($_page_settings->primary_color); ?>"></div>
                                 </div>
                                 <p class="field-help"><?php _e('Main brand color used for buttons and highlights', 'mobooking'); ?></p>
                             </div>
@@ -259,16 +262,16 @@ $user_data = get_userdata($user_id);
                         <h3 class="subsection-title"><?php _e('Preview', 'mobooking'); ?></h3>
 
                         <div class="branding-preview">
-                            <div class="preview-card" style="border-color: <?php echo esc_attr($settings->primary_color); ?>;">
-                                <div class="preview-header" style="background-color: <?php echo esc_attr($settings->primary_color); ?>;">
-                                    <?php if (!empty($settings->logo_url)) : ?>
-                                        <img src="<?php echo esc_url($settings->logo_url); ?>" alt="Logo Preview" class="preview-logo">
+                            <div class="preview-card" style="border-color: <?php echo esc_attr($_page_settings->primary_color); ?>;">
+                                <div class="preview-header" style="background-color: <?php echo esc_attr($_page_settings->primary_color); ?>;">
+                                    <?php if (!empty($_page_settings->logo_url)) : ?>
+                                        <img src="<?php echo esc_url($_page_settings->logo_url); ?>" alt="Logo Preview" class="preview-logo">
                                     <?php endif; ?>
-                                    <div class="preview-title"><?php echo esc_html($settings->company_name); ?></div>
+                                    <div class="preview-title"><?php echo esc_html($_page_settings->company_name); ?></div>
                                 </div>
                                 <div class="preview-content">
                                     <p><?php _e('This is how your branding will appear on booking forms and emails.', 'mobooking'); ?></p>
-                                    <button type="button" class="preview-button" style="background-color: <?php echo esc_attr($settings->primary_color); ?>;">
+                                    <button type="button" class="preview-button" style="background-color: <?php echo esc_attr($_page_settings->primary_color); ?>;">
                                         <?php _e('Book Now', 'mobooking'); ?>
                                     </button>
                                 </div>
@@ -304,7 +307,7 @@ $user_data = get_userdata($user_id);
                                         <span class="variable-tag" data-variable="{{email}}"><?php _e('Email', 'mobooking'); ?></span>
                                     </div>
                                 </div>
-                                <textarea id="email-header" name="email_header" class="form-control email-template" rows="6"><?php echo esc_textarea($settings->email_header); ?></textarea>
+                                <textarea id="email-header" name="email_header" class="form-control email-template" rows="6"><?php echo esc_textarea($_page_settings->email_header); ?></textarea>
                             </div>
                             <p class="field-help"><?php _e('HTML template for email headers. Click variable tags to insert them.', 'mobooking'); ?></p>
                         </div>
@@ -321,7 +324,7 @@ $user_data = get_userdata($user_id);
                                         <span class="variable-tag" data-variable="{{email}}"><?php _e('Email', 'mobooking'); ?></span>
                                     </div>
                                 </div>
-                                <textarea id="email-footer" name="email_footer" class="form-control email-template" rows="6"><?php echo esc_textarea($settings->email_footer); ?></textarea>
+                                <textarea id="email-footer" name="email_footer" class="form-control email-template" rows="6"><?php echo esc_textarea($_page_settings->email_footer); ?></textarea>
                             </div>
                             <p class="field-help"><?php _e('HTML template for email footers. Click variable tags to insert them.', 'mobooking'); ?></p>
                         </div>
@@ -329,7 +332,7 @@ $user_data = get_userdata($user_id);
                         <div class="field-group">
                             <label for="booking-confirmation-message" class="field-label"><?php _e('Booking Confirmation Message', 'mobooking'); ?></label>
                             <textarea id="booking-confirmation-message" name="booking_confirmation_message" class="form-control" rows="4"
-                                      placeholder="<?php _e('Thank you for your booking. We will contact you shortly...', 'mobooking'); ?>"><?php echo esc_textarea($settings->booking_confirmation_message); ?></textarea>
+                                      placeholder="<?php _e('Thank you for your booking. We will contact you shortly...', 'mobooking'); ?>"><?php echo esc_textarea($_page_settings->booking_confirmation_message); ?></textarea>
                             <p class="field-help"><?php _e('Message sent to customers when they make a booking', 'mobooking'); ?></p>
                         </div>
                     </div>
@@ -389,7 +392,7 @@ $user_data = get_userdata($user_id);
                                     <div class="email-message-preview">
                                         <!-- Booking confirmation message preview -->
                                     </div>
-                                    <p><?php _e('Best regards,', 'mobooking'); ?><br><?php echo esc_html($settings->company_name); ?></p>
+                                    <p><?php _e('Best regards,', 'mobooking'); ?><br><?php echo esc_html($_page_settings->company_name); ?></p>
                                 </div>
                                 <div class="email-footer-preview">
                                     <!-- Email footer preview will be generated by JavaScript -->
@@ -435,7 +438,7 @@ $user_data = get_userdata($user_id);
                         <div class="field-group">
                             <label for="terms-conditions" class="field-label"><?php _e('Terms & Conditions Text', 'mobooking'); ?></label>
                             <textarea id="terms-conditions" name="terms_conditions" class="form-control" rows="8"
-                                      placeholder="<?php _e('Enter your terms and conditions that customers must agree to...', 'mobooking'); ?>"><?php echo esc_textarea($settings->terms_conditions); ?></textarea>
+                                      placeholder="<?php _e('Enter your terms and conditions that customers must agree to...', 'mobooking'); ?>"><?php echo esc_textarea($_page_settings->terms_conditions); ?></textarea>
                             <p class="field-help"><?php _e('Legal terms and conditions that customers must accept when booking', 'mobooking'); ?></p>
                         </div>
 
@@ -605,7 +608,7 @@ $user_data = get_userdata($user_id);
                                 <span class="info-label"><?php _e('Total Bookings:', 'mobooking'); ?></span>
                                 <span class="info-value">
                                     <?php
-                                    $bookings_manager = new \MoBooking\Bookings\Manager();
+                                    // $bookings_manager is now global
                                     echo esc_html($bookings_manager->count_user_bookings($user_id));
                                     ?>
                                 </span>
@@ -614,7 +617,7 @@ $user_data = get_userdata($user_id);
                                 <span class="info-label"><?php _e('Active Services:', 'mobooking'); ?></span>
                                 <span class="info-value">
                                     <?php
-                                    $services_manager = new \MoBooking\Services\ServicesManager();
+                                    // $services_manager is now global
                                     $services = $services_manager->get_user_services($user_id);
                                     echo esc_html(count($services));
                                     ?>

--- a/page-single-booking.php
+++ b/page-single-booking.php
@@ -31,8 +31,15 @@ if (!$booking) {
     return;
 }
 
+global $user_id, $current_user, $settings,
+       $bookings_manager, $services_manager, $geography_manager,
+       $settings_manager, $discounts_manager, $booking_form_manager, $options_manager;
+
+// Managers are now initialized globally by mobooking_setup_dashboard_globals().
+// They are available here via the global keyword.
+
 // Get services data
-$services_manager = new \MoBooking\Services\ServicesManager();
+// $services_manager is now global
 $services_data     = $booking->services;
 $services_list     = array();
 


### PR DESCRIPTION
This commit addresses several fatal errors reported on dashboard pages:

1.  **`$options_manager` null in `page-services.php`**:
    - Added `$options_manager` to the global declaration and initialization logic within `mobooking_setup_dashboard_globals()` in `includes/rewrite-rules.php`.
    - Verified that `page-services.php` correctly declares `global $options_manager;`.

2.  **`$bookings_manager` null in `page-overview.php` leading to `method_exists()` error**:
    - Added `is_object()` checks before calls to `method_exists()` on `$bookings_manager`, `$services_manager`, and `$geography_manager` within `page-overview.php`. This prevents the fatal TypeError if any of these manager objects are null due to issues in their initialization upstream (e.g., class loading problems).

3.  **Undefined method `get_supported_countries()` in `page-areas.php`**:
    - Implemented the `get_supported_countries()` public method in `classes/Geography/Manager.php`. This method returns a list of supported countries and their properties (name, local data/API availability) as expected by `page-areas.php`.

These changes should make the dashboard pages more resilient and fix the reported fatal errors, allowing the pages to load correctly.