### PR TITLE
I've made a fix to correct case sensitivity in autoloader paths.

### DIFF
--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -21,8 +21,9 @@ spl_autoload_register(function ($class) {
     // Remove MoBooking namespace prefix
     $relative_class = str_replace('MoBooking\\', '', $class);
     
-    // Convert namespace separators to directory separators
-    $file = MOBOOKING_PATH . '/classes/' . str_replace('\\', '/', $relative_class) . '.php';
+    // Convert namespace separators to directory separators and path to lowercase
+    $file_path_segment = str_replace('\\', '/', $relative_class);
+    $file = MOBOOKING_PATH . '/classes/' . strtolower($file_path_segment) . '.php';
 
     // Load the file if it exists
     if (file_exists($file)) {
@@ -45,8 +46,8 @@ spl_autoload_register(function ($class) {
  */
 function mobooking_load_critical_files() {
     $critical_files = array(
-        '/classes/Core/Loader.php',
-        '/classes/Database/Manager.php',
+        '/classes/core/loader.php',      // Corrected case
+        '/classes/database/manager.php', // Corrected case
     );
     
     foreach ($critical_files as $file) {


### PR DESCRIPTION
This resolves a fatal error: `Class "MoBooking\Core\Loader" not found` which occurred on case-sensitive file systems.

The autoloader and critical file loading mechanism were attempting to load classes using paths with incorrect casing (e.g., `classes/Core/Loader.php`) while the actual file paths were lowercase (e.g., `classes/core/loader.php`).

Changes in `includes/autoloader.php`:
- I modified `mobooking_load_critical_files()` to use correct lowercase paths for `classes/core/loader.php` and `classes/database/manager.php`.
- I updated the `spl_autoload_register` callback to convert the class-derived path segment to lowercase before attempting to load the file. This ensures paths like `MoBooking\Core\Loader` correctly resolve to `classes/core/loader.php`.