### PR TITLE
Add detailed logging to critical file loading.

### DIFF
--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -45,15 +45,36 @@ spl_autoload_register(function ($class) {
  * Manually load critical files that might be needed before autoloader
  */
 function mobooking_load_critical_files() {
-    $critical_files = array(
-        '/classes/core/loader.php',      // Corrected case
-        '/classes/database/manager.php', // Corrected case
+    $critical_files_map = array(
+        'MoBooking\Core\Loader' => '/classes/core/loader.php',
+        'MoBooking\Database\Manager' => '/classes/database/manager.php',
+        // Add other truly critical classes here if needed
     );
-    
-    foreach ($critical_files as $file) {
+
+    foreach ($critical_files_map as $class_name => $file) {
         $file_path = MOBOOKING_PATH . $file;
+
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log("MoBooking CRITICAL LOAD ATTEMPT: Attempting to load class {$class_name} from {$file_path}. MOBOOKING_PATH is: " . MOBOOKING_PATH);
+        }
+
         if (file_exists($file_path)) {
             require_once $file_path;
+
+            // Explicit check after require_once
+            if (!class_exists($class_name, false)) { // Use false to prevent re-triggering autoloader
+                if (defined('WP_DEBUG') && WP_DEBUG) {
+                    error_log("MoBooking CRITICAL LOAD FAILURE: Class {$class_name} not found AFTER attempting to require_once {$file_path}.");
+                }
+            } else {
+                if (defined('WP_DEBUG') && WP_DEBUG) {
+                    error_log("MoBooking CRITICAL LOAD SUCCESS: Class {$class_name} was successfully loaded from {$file_path}.");
+                }
+            }
+        } else {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log("MoBooking CRITICAL LOAD FAILURE: File {$file_path} for class {$class_name} not found. Check MOBOOKING_PATH and file existence.");
+            }
         }
     }
 }


### PR DESCRIPTION
To diagnose a persistent 'Class "MoBooking\Core\Loader" not found' error, this commit enhances the `mobooking_load_critical_files()` function in `includes/autoloader.php`.

The function now logs:
- The attempt to load each critical class, including the fully constructed file path and the value of `MOBOOKING_PATH`.
- The result of the `file_exists()` check for the path.
- If `file_exists()` is true, it logs whether `class_exists($class_name, false)` returns true or false immediately after `require_once` is called for the file.

This detailed logging, when `WP_DEBUG` is enabled, will provide crucial information in `debug.log` to pinpoint the exact stage at which the loading of critical classes like `MoBooking\Core\Loader` is failing.